### PR TITLE
Support clang-12.0.0

### DIFF
--- a/toolchain/cc_toolchain_config.bzl.tpl
+++ b/toolchain/cc_toolchain_config.bzl.tpl
@@ -168,6 +168,9 @@ def _impl(ctx):
             "-headerpad_max_install_names",
             "-undefined",
             "dynamic_lookup",
+
+            # For Big Sur/Catalina compatibility
+            "-mlinker-version=400",
         ]
     else:
         fail("Unreachable")

--- a/toolchain/internal/llvm_distributions.bzl
+++ b/toolchain/internal/llvm_distributions.bzl
@@ -120,6 +120,18 @@ _llvm_distributions = {
     "clang+llvm-11.0.0-x86_64-linux-gnu-ubuntu-20.04.tar.xz": "829f5fb0ebda1d8716464394f97d5475d465ddc7bea2879c0601316b611ff6db",
     "clang+llvm-11.0.0-amd64-pc-solaris2.11.tar.xz": "031699337d703fe42843a8326f94079fd67e46b60f25be5bdf47664e158e0b43",
     "clang+llvm-11.0.0-x86_64-apple-darwin.tar.xz": "b93886ab0025cbbdbb08b46e5e403a462b0ce034811c929e96ed66c2b07fe63a",
+
+    # 12.0.0
+    "clang+llvm-12.0.0-armv7a-linux-gnueabihf.tar.xz": "697d432c2572e48fc04118fc7cec63c9477ef2e8a7cca2c0b32e52f9705ab1cc",
+    "clang+llvm-12.0.0-i386-unknown-freebsd11.tar.xz": "8298a026f74165bf6088c1c942c22bd7532b12cd2b916f7673bdaf522abe41b0",
+    "clang+llvm-12.0.0-x86_64-apple-darwin.tar.xz": "7bc2259bf75c003f644882460fc8e844ddb23b27236fe43a2787870a4cd8ab50",
+    "clang+llvm-12.0.0-amd64-unknown-freebsd11.tar.xz": "8ff2ae0863d4cbe88ace6cbcce64a1a6c9a8f1237f635125a5d580b2639bba61",
+    "clang+llvm-12.0.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz": "9694f4df031c614dbe59b8431f94c68631971ad44173eecc1ea1a9e8ee27b2a3",
+    "clang+llvm-12.0.0-aarch64-linux-gnu.tar.xz": "d05f0b04fb248ce1e7a61fcd2087e6be8bc4b06b2cc348792f383abf414dec48",
+    "clang+llvm-12.0.0-amd64-unknown-freebsd12.tar.xz": "0a90d2cf8a3d71d7d4a6bee3e085405ebc37a854311bce82d6845d93b19fcc87",
+    "clang+llvm-12.0.0-x86_64-linux-sles12.4.tar.xz": "00c25261e303080c2e8d55413a73c60913cdb39cfd47587d6817a86fe52565e9",
+    "clang+llvm-12.0.0-i386-unknown-freebsd12.tar.xz": "1e61921735fd11754df193826306f0352c99ca6013e22f40a7fc77f0b20162be",
+    "clang+llvm-12.0.0-x86_64-linux-gnu-ubuntu-20.04.tar.xz": "a9ff205eb0b73ca7c86afc6432eed1c2d49133bd0d49e47b15be59bbf0dd292e",
 }
 
 # Note: Unlike the user-specified llvm_mirror attribute, the URL prefixes in
@@ -135,6 +147,7 @@ _llvm_distributions_base_url = {
     "10.0.0": "https://github.com/llvm/llvm-project/releases/download/llvmorg-",
     "10.0.1": "https://github.com/llvm/llvm-project/releases/download/llvmorg-",
     "11.0.0": "https://github.com/llvm/llvm-project/releases/download/llvmorg-",
+    "12.0.0": "https://github.com/llvm/llvm-project/releases/download/llvmorg-",
 }
 
 def _python(rctx):

--- a/toolchain/tools/llvm_release_name.py
+++ b/toolchain/tools/llvm_release_name.py
@@ -77,7 +77,7 @@ def _linux(llvm_version):
         os_name = "linux-sles%s" % version
     elif distname == "ubuntu" and version.startswith("14.04"):
         os_name = "linux-gnu-ubuntu-14.04"
-    elif (distname == "ubuntu" and version.startswith("20")) or (distname == "linuxmint" and version.startswith("20")):
+    elif (distname == "ubuntu" or distname == "linuxmint" or distname == "pop") and version.startswith("20"):
         if major_llvm_version < 11:
             # There is no binary packages specifically for 20.04, but those for 18.04 works on
             # 20.04
@@ -85,13 +85,13 @@ def _linux(llvm_version):
         else:
             # release 11.0.0 started providing packaging for ubuntu 20
             os_name = "linux-gnu-ubuntu-20.04"
-
+            
     elif (distname == "ubuntu" and version.startswith("18.04")) or (distname == "linuxmint" and version.startswith("19")):
         if major_llvm_version >= 12:
+            # There is no binary release of 12.0.0 for 18.04, but 16.04 works
             os_name = "linux-gnu-ubuntu-16.04"
         else:
             os_name = "linux-gnu-ubuntu-18.04"
-
     elif distname in ["arch", "ubuntu", "manjaro"] or (distname == "linuxmint" and version.startswith("18")):
         os_name = "linux-gnu-ubuntu-16.04"
     elif distname == "debian" and (version is None or int(version) == 10):

--- a/toolchain/tools/llvm_release_name.py
+++ b/toolchain/tools/llvm_release_name.py
@@ -77,7 +77,7 @@ def _linux(llvm_version):
         os_name = "linux-sles%s" % version
     elif distname == "ubuntu" and version.startswith("14.04"):
         os_name = "linux-gnu-ubuntu-14.04"
-    elif (distname == "ubuntu" and version.startswith("20.04")) or (distname == "linuxmint" and version.startswith("20")):
+    elif (distname == "ubuntu" and version.startswith("20")) or (distname == "linuxmint" and version.startswith("20")):
         if major_llvm_version < 11:
             # There is no binary packages specifically for 20.04, but those for 18.04 works on
             # 20.04
@@ -90,13 +90,6 @@ def _linux(llvm_version):
         if major_llvm_version >= 12:
             os_name = "linux-gnu-ubuntu-16.04"
         else:
-            os_name = "linux-gnu-ubuntu-18.04"
-
-    elif (distname == "ubuntu" and version.startswith("20")) or (distname == "pop" and version.startswith("20")):
-        if major_llvm_version >= 12:
-            os_name = "linux-gnu-ubuntu-20.04"
-        else:
-            # use ubuntu 18.04 clang LLVM release for ubuntu 20.04
             os_name = "linux-gnu-ubuntu-18.04"
 
     elif distname in ["arch", "ubuntu", "manjaro"] or (distname == "linuxmint" and version.startswith("18")):

--- a/toolchain/tools/llvm_release_name.py
+++ b/toolchain/tools/llvm_release_name.py
@@ -85,15 +85,20 @@ def _linux(llvm_version):
         else:
             # release 11.0.0 started providing packaging for ubuntu 20
             os_name = "linux-gnu-ubuntu-20.04"
-            
+
     elif (distname == "ubuntu" and version.startswith("18.04")) or (distname == "linuxmint" and version.startswith("19")):
         if major_llvm_version >= 12:
             os_name = "linux-gnu-ubuntu-16.04"
         else:
             os_name = "linux-gnu-ubuntu-18.04"
+
     elif (distname == "ubuntu" and version.startswith("20")) or (distname == "pop" and version.startswith("20")):
-        # use ubuntu 18.04 clang LLVM release for ubuntu 20.04
-        os_name = "linux-gnu-ubuntu-18.04"
+        if major_llvm_version >= 12:
+            os_name = "linux-gnu-ubuntu-20.04"
+        else:
+            # use ubuntu 18.04 clang LLVM release for ubuntu 20.04
+            os_name = "linux-gnu-ubuntu-18.04"
+
     elif distname in ["arch", "ubuntu", "manjaro"] or (distname == "linuxmint" and version.startswith("18")):
         os_name = "linux-gnu-ubuntu-16.04"
     elif distname == "debian" and (version is None or int(version) == 10):

--- a/toolchain/tools/llvm_release_name.py
+++ b/toolchain/tools/llvm_release_name.py
@@ -87,7 +87,10 @@ def _linux(llvm_version):
             os_name = "linux-gnu-ubuntu-20.04"
             
     elif (distname == "ubuntu" and version.startswith("18.04")) or (distname == "linuxmint" and version.startswith("19")):
-        os_name = "linux-gnu-ubuntu-18.04"
+        if major_llvm_version >= 12:
+            os_name = "linux-gnu-ubuntu-16.04"
+        else:
+            os_name = "linux-gnu-ubuntu-18.04"
     elif (distname == "ubuntu" and version.startswith("20")) or (distname == "pop" and version.startswith("20")):
         # use ubuntu 18.04 clang LLVM release for ubuntu 20.04
         os_name = "linux-gnu-ubuntu-18.04"


### PR DESCRIPTION
Add the archives for clang-12, and add a special rule to say that ubuntu-18.04 should use the ubuntu-16.04 clang build.