### PR TITLE
add support for deducing local arm64 toolchains on linux

### DIFF
--- a/toolchain/BUILD.tpl
+++ b/toolchain/BUILD.tpl
@@ -109,9 +109,9 @@ toolchain(
 
 load("@com_grail_bazel_toolchain//toolchain:rules.bzl", "conditional_cc_toolchain")
 
-conditional_cc_toolchain("cc-clang-linux-x86_64", False, %{absolute_paths})
-conditional_cc_toolchain("cc-clang-linux-aarch64", False, %{absolute_paths})
-conditional_cc_toolchain("cc-clang-darwin", True, %{absolute_paths})
+conditional_cc_toolchain("cc-clang-linux-x86_64", "x86_64", False, %{absolute_paths})
+conditional_cc_toolchain("cc-clang-linux-aarch64", "aarch64", False, %{absolute_paths})
+conditional_cc_toolchain("cc-clang-darwin", "x86_64", True, %{absolute_paths})
 
 ## LLVM toolchain files
 # Needed when not using absolute paths.

--- a/toolchain/BUILD.tpl
+++ b/toolchain/BUILD.tpl
@@ -39,9 +39,11 @@ filegroup(
 cc_toolchain_suite(
     name = "toolchain",
     toolchains = {
-        "k8|clang": ":cc-clang-linux",
+        "k8|clang": ":cc-clang-linux-x86_64",
+        "aarch64|clang": ":cc-clang-linux-aarch64",
         "darwin|clang": ":cc-clang-darwin",
-        "k8": ":cc-clang-linux",
+        "k8": ":cc-clang-linux-x86_64",
+        "aarch64": ":cc-clang-linux-aarch64",
         "darwin": ":cc-clang-darwin",
     },
 )
@@ -49,8 +51,13 @@ cc_toolchain_suite(
 load(":cc_toolchain_config.bzl", "cc_toolchain_config")
 
 cc_toolchain_config(
-    name = "local_linux",
+    name = "local_linux-x86_64",
     cpu = "k8",
+)
+
+cc_toolchain_config(
+    name = "local_linux-aarch64",
+    cpu = "aarch64",
 )
 
 cc_toolchain_config(
@@ -73,7 +80,7 @@ toolchain(
 )
 
 toolchain(
-    name = "cc-toolchain-linux",
+    name = "cc-toolchain-linux-x86_64",
     exec_compatible_with = [
         "@platforms//cpu:x86_64",
         "@platforms//os:linux",
@@ -82,13 +89,28 @@ toolchain(
         "@platforms//cpu:x86_64",
         "@platforms//os:linux",
     ],
-    toolchain = ":cc-clang-linux",
+    toolchain = ":cc-clang-linux-x86_64",
+    toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
+)
+
+toolchain(
+    name = "cc-toolchain-linux-aarch64",
+    exec_compatible_with = [
+        "@platforms//cpu:aarch64",
+        "@platforms//os:linux",
+    ],
+    target_compatible_with = [
+        "@platforms//cpu:aarch64",
+        "@platforms//os:linux",
+    ],
+    toolchain = ":cc-clang-linux-aarch64",
     toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
 )
 
 load("@com_grail_bazel_toolchain//toolchain:rules.bzl", "conditional_cc_toolchain")
 
-conditional_cc_toolchain("cc-clang-linux", False, %{absolute_paths})
+conditional_cc_toolchain("cc-clang-linux-x86_64", False, %{absolute_paths})
+conditional_cc_toolchain("cc-clang-linux-aarch64", False, %{absolute_paths})
 conditional_cc_toolchain("cc-clang-darwin", True, %{absolute_paths})
 
 ## LLVM toolchain files

--- a/toolchain/cc_toolchain_config.bzl.tpl
+++ b/toolchain/cc_toolchain_config.bzl.tpl
@@ -565,13 +565,21 @@ def _impl(ctx):
         "%{toolchain_path_prefix}/lib/clang/%{llvm_version}/share",
         "%{toolchain_path_prefix}lib64/clang/%{llvm_version}/include",
     ]
-    if (ctx.attr.cpu == "k8" or ctx.attr.cpu == "aarch64"):
+    if (ctx.attr.cpu == "k8"):
         cxx_builtin_include_directories += [
             "%{sysroot_prefix}/include",
             "%{sysroot_prefix}/usr/include",
             "%{sysroot_prefix}/usr/local/include",
         ] + [
             %{k8_additional_cxx_builtin_include_directories}
+        ]
+    elif (ctx.attr.cpu == "aarch64"):
+        cxx_builtin_include_directories += [
+            "%{sysroot_prefix}/include",
+            "%{sysroot_prefix}/usr/include",
+            "%{sysroot_prefix}/usr/local/include",
+        ] + [
+            %{aarch64_additional_cxx_builtin_include_directories}
         ]
     elif (ctx.attr.cpu == "darwin"):
         cxx_builtin_include_directories += [

--- a/toolchain/cc_toolchain_config.bzl.tpl
+++ b/toolchain/cc_toolchain_config.bzl.tpl
@@ -565,21 +565,13 @@ def _impl(ctx):
         "%{toolchain_path_prefix}/lib/clang/%{llvm_version}/share",
         "%{toolchain_path_prefix}lib64/clang/%{llvm_version}/include",
     ]
-    if (ctx.attr.cpu == "k8"):
+    if (ctx.attr.cpu == "k8" or ctx.attr.cpu == "aarch64"):
         cxx_builtin_include_directories += [
             "%{sysroot_prefix}/include",
             "%{sysroot_prefix}/usr/include",
             "%{sysroot_prefix}/usr/local/include",
         ] + [
             %{k8_additional_cxx_builtin_include_directories}
-        ]
-    elif (ctx.attr.cpu == "aarch64"):
-        cxx_builtin_include_directories += [
-            "%{sysroot_prefix}/include",
-            "%{sysroot_prefix}/usr/include",
-            "%{sysroot_prefix}/usr/local/include",
-        ] + [
-            %{aarch64_additional_cxx_builtin_include_directories}
         ]
     elif (ctx.attr.cpu == "darwin"):
         cxx_builtin_include_directories += [

--- a/toolchain/cc_toolchain_config.bzl.tpl
+++ b/toolchain/cc_toolchain_config.bzl.tpl
@@ -34,12 +34,16 @@ def _impl(ctx):
     if (ctx.attr.cpu == "darwin"):
         toolchain_identifier = "clang-darwin"
     elif (ctx.attr.cpu == "k8"):
-        toolchain_identifier = "clang-linux"
+        toolchain_identifier = "clang-linux-x86_64"
+    elif (ctx.attr.cpu == "aarch64"):
+        toolchain_identifier = "clang-linux-aarch64"
     else:
         fail("Unreachable")
 
     if (ctx.attr.cpu == "k8"):
         host_system_name = "x86_64"
+    elif (ctx.attr.cpu == "aarch64"):
+        host_system_name = "aarch64"
     elif (ctx.attr.cpu == "darwin"):
         host_system_name = "x86_64-apple-macosx"
     else:
@@ -49,6 +53,8 @@ def _impl(ctx):
         target_system_name = "x86_64-apple-macosx"
     elif (ctx.attr.cpu == "k8"):
         target_system_name = "x86_64-unknown-linux-gnu"
+    elif (ctx.attr.cpu == "aarch64"):
+        target_system_name = "aarch64-unknown-linux-gnu"
     else:
         fail("Unreachable")
 
@@ -56,10 +62,14 @@ def _impl(ctx):
         target_cpu = "darwin"
     elif (ctx.attr.cpu == "k8"):
         target_cpu = "k8"
+    elif (ctx.attr.cpu == "aarch64"):
+        target_cpu = "aarch64"
     else:
         fail("Unreachable")
 
     if (ctx.attr.cpu == "k8"):
+        target_libc = "glibc_unknown"
+    elif (ctx.attr.cpu == "aarch64"):
         target_libc = "glibc_unknown"
     elif (ctx.attr.cpu == "darwin"):
         target_libc = "macosx"
@@ -67,12 +77,15 @@ def _impl(ctx):
         fail("Unreachable")
 
     if (ctx.attr.cpu == "darwin" or
-        ctx.attr.cpu == "k8"):
+        ctx.attr.cpu == "k8" or
+        ctx.attr.cpu == "aarch64"):
         compiler = "clang"
     else:
         fail("Unreachable")
 
     if (ctx.attr.cpu == "k8"):
+        abi_version = "clang"
+    elif (ctx.attr.cpu == "aarch64"):
         abi_version = "clang"
     elif (ctx.attr.cpu == "darwin"):
         abi_version = "darwin_x86_64"
@@ -83,13 +96,16 @@ def _impl(ctx):
         abi_libc_version = "darwin_x86_64"
     elif (ctx.attr.cpu == "k8"):
         abi_libc_version = "glibc_unknown"
+    elif (ctx.attr.cpu == "aarch64"):
+        abi_libc_version = "glibc_unknown"
     else:
         fail("Unreachable")
 
     cc_target_os = None
 
     if (ctx.attr.cpu == "darwin" or
-        ctx.attr.cpu == "k8"):
+        ctx.attr.cpu == "k8" or
+        ctx.attr.cpu == "aarch64"):
         builtin_sysroot = "%{sysroot_path}"
     else:
         fail("Unreachable")
@@ -144,7 +160,7 @@ def _impl(ctx):
 
     action_configs = []
 
-    if ctx.attr.cpu == "k8":
+    if ctx.attr.cpu == "k8" or ctx.attr.cpu == "aarch64":
         linker_flags = [
             # Use the lld linker.
             "-fuse-ld=lld",
@@ -234,7 +250,7 @@ def _impl(ctx):
                 flag_groups = [flag_group(flags = ["-Wl,--gc-sections"])],
                 with_features = [with_feature_set(features = ["opt"])],
             ),
-        ] if ctx.attr.cpu == "k8" else []) + ([
+        ] if ctx.attr.cpu == "k8" or ctx.attr.cpu == "aarch64" else []) + ([
             flag_set(
                 actions = all_link_actions,
                 flag_groups = [
@@ -557,6 +573,14 @@ def _impl(ctx):
         ] + [
             %{k8_additional_cxx_builtin_include_directories}
         ]
+    elif (ctx.attr.cpu == "aarch64"):
+        cxx_builtin_include_directories += [
+            "%{sysroot_prefix}/include",
+            "%{sysroot_prefix}/usr/include",
+            "%{sysroot_prefix}/usr/local/include",
+        ] + [
+            %{aarch64_additional_cxx_builtin_include_directories}
+        ]
     elif (ctx.attr.cpu == "darwin"):
         cxx_builtin_include_directories += [
             "%{sysroot_prefix}/usr/include",
@@ -579,10 +603,12 @@ def _impl(ctx):
         ]
     elif (ctx.attr.cpu == "k8"):
         make_variables = []
+    elif (ctx.attr.cpu == "aarch64"):
+        make_variables = []
     else:
         fail("Unreachable")
 
-    if (ctx.attr.cpu == "k8"):
+    if (ctx.attr.cpu == "k8" or ctx.attr.cpu == "aarch64"):
         tool_paths = [
             tool_path(
                 name = "ld",
@@ -693,6 +719,7 @@ cc_toolchain_config = rule(
             values = [
                 "darwin",
                 "k8",
+                "aarch64"
             ],
         ),
     },

--- a/toolchain/internal/configure.bzl
+++ b/toolchain/internal/configure.bzl
@@ -65,6 +65,7 @@ def llvm_register_toolchains():
         "%{absolute_paths}": "True" if rctx.attr.absolute_paths else "False",
         "%{makevars_ld_flags}": _makevars_ld_flags(rctx),
         "%{k8_additional_cxx_builtin_include_directories}": _include_dirs_str(rctx, "k8"),
+        "%{aarch64_additional_cxx_builtin_include_directories}": _include_dirs_str(rctx, "aarch64"),
         "%{darwin_additional_cxx_builtin_include_directories}": _include_dirs_str(rctx, "darwin"),
     }
 

--- a/toolchain/internal/configure.bzl
+++ b/toolchain/internal/configure.bzl
@@ -112,11 +112,11 @@ def llvm_register_toolchains():
     rctx.execute(["cp", "lib/libc++.a", "lib/libc++-static.a"])
     rctx.execute(["cp", "lib/libc++abi.a", "lib/libc++abi-static.a"])
 
-def conditional_cc_toolchain(name, darwin, absolute_paths = False):
+def conditional_cc_toolchain(name, cpu, darwin, absolute_paths = False):
     # Toolchain macro for BUILD file to use conditional logic.
 
-    toolchain_config = "local_darwin" if darwin else "local_linux"
-    toolchain_identifier = "clang-darwin" if darwin else "clang-linux"
+    toolchain_config = "local_darwin" if darwin else ("local_linux-%s" % cpu)
+    toolchain_identifier = "clang-darwin" if darwin else ("clang-linux-%s" % cpu)
 
     if absolute_paths:
         _cc_toolchain(

--- a/toolchain/toolchains.bzl.tpl
+++ b/toolchain/toolchains.bzl.tpl
@@ -14,6 +14,7 @@
 
 def llvm_register_toolchains():
     native.register_toolchains(
-        "@%{repo_name}//:cc-toolchain-linux",
+        "@%{repo_name}//:cc-toolchain-linux-aarch64",
+        "@%{repo_name}//:cc-toolchain-linux-x86_64",
         "@%{repo_name}//:cc-toolchain-darwin",
     )


### PR DESCRIPTION
This is either gross or straightforward, depending on how you feel about things: we get a local arm64 toolchain on Linux working by looking for everywhere we had cases for `cpu == "k8"` or similar, and adding a case for `cpu == "aarch64"`.

I think this also points the way to hacking in support for M1 Macs; we just have to add the relevant cases for the new cpu architecture (and rearrange things to ensure that `cpu == "aarch64"` doesn't imply `linux`).

It would be better to use the proper upstream support, but given that involves hacking on Sorbet's emscripten setup, I vote to defer that to another day.