### PR TITLE
Add support for Void Linux

### DIFF
--- a/toolchain/tools/llvm_release_name.py
+++ b/toolchain/tools/llvm_release_name.py
@@ -110,7 +110,7 @@ def _linux(llvm_version):
     elif distname == "amzn" and major_llvm_version >= 7:
         os_name = "linux-gnu-ubuntu-18.04"
     elif distname == "void" and major_llvm_version >= 7:
-        os_name = "linux-gnu-ubuntu-18.04"
+        os_name = "linux-gnu-ubuntu-20.04"
     else:
         sys.exit("Unsupported linux distribution and version: %s, %s" % (distname, version))
 


### PR DESCRIPTION
This adds [Void Linux](https://voidlinux.org/) as a possible OS target. Verified that this works on a reasonably-up-to-date Void Linux install.
