### PR TITLE
remove Mac libunwind files from the sysroot

### DIFF
--- a/toolchain/internal/configure.bzl
+++ b/toolchain/internal/configure.bzl
@@ -112,6 +112,7 @@ def llvm_register_toolchains():
 
     rctx.execute(["cp", "lib/libc++.a", "lib/libc++-static.a"])
     rctx.execute(["cp", "lib/libc++abi.a", "lib/libc++abi-static.a"])
+    rctx.execute(["rm", "-f", "lib/libunwind.dylib", "lib/libunwind.1.dylib", "lib/libunwind.1.0.dylib"])
 
 def conditional_cc_toolchain(name, cpu, darwin, absolute_paths = False):
     # Toolchain macro for BUILD file to use conditional logic.


### PR DESCRIPTION
This PR fixes a linking problem with the most recent version of `/usr/bin/ld` (1053.12), which seems to be the default for OS X Sonoma (14.x) for Sorbet builds.

The clang-distributed `libunwind` winds up in the Bazel sandbox when we are linking C++ binaries (and other things, but binaries are the immediate problem that we've noticed).  This `libunwind` has an `LC_ID_DYLIB` of `@rpath/libunwind.1.dylib`:

```
$ otool -l  /private/var/tmp/_bazel/44008fe339dc94537f734f1bc517a5ea/external/llvm_toolchain_12_0_0/lib/libunwind.1.0.dylib
...
Load command 4
          cmd LC_ID_DYLIB
      cmdsize 56
         name @rpath/libunwind.1.dylib (offset 24)
   time stamp 1 Wed Dec 31 19:00:01 1969
      current version 1.0.0
compatibility version 1.0.0
```

`LC_ID_DYLIB` is a library's "install name", roughly "here's where you should find the library at program runtime".

On this version of the linker -- and seemingly only this version of the linker -- `/usr/bin/ld` has determined that we need to link `libunwind` despite `-lunwind` not being present on the command line for the linker.  It's possible that the linker now consults paths specified via `-L`, since we pass `-L/private/var/tmp/_bazel/44008fe339dc94537f734f1bc517a5ea/external/llvm_toolchain_12_0_0/lib` so that the compiler can pick up e.g. `libc++` from the clang installation.  I can't verify this behavior, since [Apple's open source releases](https://opensource.apple.com/releases/) do not yet contain the 1053.12 version of `ld64`.

Once the linker has located clang's `libunwind`, it needs to be able to copy the library's install name into the output binary.  So the binary now contains instructions to look for `@rpath/libunwind.1.dylib`.  This means that a) the binary needs a runtime path list for locating said library, so `@rpath` has something to resolve against; and b) `libunwind.1.dylib` would need to be distributed with the binary in some way.  The linker does realize that something is going wrong and issues the cryptic warning:

```
ld: warning: reexported library with install name '@rpath/libunwind.1.dylib' found at '/private/var/tmp/_bazel/44008fe339dc94537f734f1bc517a5ea/external/llvm_toolchain_12_0_0/lib/libunwind.1.0.dylib' couldn't be matched with any parent library and will be linked directly
```

It's not obvious to me what the "parent library" here is -- I wish we had the source for the linker -- but it seems to be saying "hey, something weird is going wrong with your app".

Then, of course, once the program that has been linked in this way starts executing, the dynamic linker tries to look for `@rpath/libunwind.1.dylib` and not having an `@rpath` (which the binary should have contained in its load commands), it issues messages like:

```
dyld[34904]: Library not loaded: @rpath/libunwind.1.dylib
  Referenced from: <3518F2E7-E28A-30C8-91A8-E1A930CC8977> /private/var/tmp/_bazel/ea9c9c7f81781010c94c1033f6138a14/execroot/com_stripe_ruby_typer/bazel-out/darwin-opt-exec-2B5CBBC6/bin/parser/generate_ast
  Reason: no LC_RPATH's found
```

and the binary falls over.

Since the linking of `libunwind` is triggered by the linker itself, rather than anything passed to clang, I don't see any better solution than trying to remove these files from the toolchain so that the linker won't go finding them.  This solution seems to work for cross-compiling x86-64 binaries from an M${N} mac on 10.12, 10.13, and 10.14 -- not sure what linker versions all of those are using.  I don't know if this is a fully general solution, since I don't know under what circumstances clang might try to link in its own `libunwind`.  If I'm reading the clang 12.0 source correctly, I think the default is to not link `libunwind` and rely on the system, but it does look like there are options to force linking of clang's `libunwind`.

After taking these files away and examining the `-t` output of the linker:

```
     -t      Logs each file (object, archive, or dylib) the linker loads.  Useful for debugging problems with search paths where the wrong library is loaded.
```

it looks like the linker is "correctly" picking up `libunwind` from:

```
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.4.sdk/usr/lib/system/libunwind.tbd
```

along with a host of other `.tbd` files in that directory, presumably that the linker automatically adds.

I haven't checked whether subsequent versions of clang distribute `libunwind` with their Mac tarballs.

cc @Morriar