### PR TITLE
explicitly specify paths to static libraries

### DIFF
--- a/toolchain/cc_toolchain_config.bzl.tpl
+++ b/toolchain/cc_toolchain_config.bzl.tpl
@@ -255,10 +255,12 @@ def _impl(ctx):
                 actions = all_link_actions,
                 flag_groups = [
                     flag_group(
+                        # Explicitly specify the archive paths rather than using -L
+                        # so that the linker doesn't go poking around in toolchain_path_prefix
+                        # for libraries like libunwind -- at least by default.
                         flags = [
-                            "-L%{toolchain_path_prefix}/lib",
-                            "-lc++-static",
-                            "-lc++abi-static",
+                            "%{toolchain_path_prefix}/lib/libc++-static.a",
+                            "%{toolchain_path_prefix}/lib/libc++abi-static.a",
                         ],
                     ),
                 ],

--- a/toolchain/internal/configure.bzl
+++ b/toolchain/internal/configure.bzl
@@ -112,7 +112,6 @@ def llvm_register_toolchains():
 
     rctx.execute(["cp", "lib/libc++.a", "lib/libc++-static.a"])
     rctx.execute(["cp", "lib/libc++abi.a", "lib/libc++abi-static.a"])
-    rctx.execute(["rm", "-f", "lib/libunwind.dylib", "lib/libunwind.1.dylib", "lib/libunwind.1.0.dylib"])
 
 def conditional_cc_toolchain(name, cpu, darwin, absolute_paths = False):
     # Toolchain macro for BUILD file to use conditional logic.


### PR DESCRIPTION
This PR is, I think, a better response to the issues outlined in #6 -- if the linker insists on scanning `-L` directories for its own internal libraries that it's attempting to link, then the better thing to do is not modify the toolchain's libraries directory, but instead simply explicitly say which static archives we want to link against.

This also fixes the linking issues on OS X Sonoma described in the above issue; I will note that clang generates the full path to its own `libclang_rt.osx.a` file that it inserts on the command line, probably for this same reason.  Full paths are also used for ASan dylibs in ASan builds.