### PR TITLE
Add `llvm_toolchain` support for darwin-arm64

### DIFF
--- a/toolchain/BUILD.tpl
+++ b/toolchain/BUILD.tpl
@@ -41,10 +41,11 @@ cc_toolchain_suite(
     toolchains = {
         "k8|clang": ":cc-clang-linux-x86_64",
         "aarch64|clang": ":cc-clang-linux-aarch64",
-        "darwin|clang": ":cc-clang-darwin",
+        "darwin|clang": ":cc-clang-darwin-x86_64",
         "k8": ":cc-clang-linux-x86_64",
         "aarch64": ":cc-clang-linux-aarch64",
-        "darwin": ":cc-clang-darwin",
+        "darwin-x86_64": ":cc-clang-darwin-x86_64",
+        "darwin_arm64": ":cc-clang-darwin-arm64",
     },
 )
 
@@ -61,12 +62,17 @@ cc_toolchain_config(
 )
 
 cc_toolchain_config(
-    name = "local_darwin",
-    cpu = "darwin",
+    name = "local_darwin-x86_64",
+    cpu = "darwin-x86_64",
+)
+
+cc_toolchain_config(
+    name = "local_darwin-arm64",
+    cpu = "darwin-arm64",
 )
 
 toolchain(
-    name = "cc-toolchain-darwin",
+    name = "cc-toolchain-darwin-x86_64",
     exec_compatible_with = [
         "@platforms//cpu:x86_64",
         "@platforms//os:osx",
@@ -75,7 +81,21 @@ toolchain(
         "@platforms//cpu:x86_64",
         "@platforms//os:osx",
     ],
-    toolchain = ":cc-clang-darwin",
+    toolchain = ":cc-clang-darwin-x86_64",
+    toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
+)
+
+toolchain(
+    name = "cc-toolchain-darwin-arm64",
+    exec_compatible_with = [
+        "@platforms//cpu:arm64",
+        "@platforms//os:osx",
+    ],
+    target_compatible_with = [
+        "@platforms//cpu:arm64",
+        "@platforms//os:osx",
+    ],
+    toolchain = ":cc-clang-darwin-arm64",
     toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
 )
 
@@ -111,7 +131,8 @@ load("@com_grail_bazel_toolchain//toolchain:rules.bzl", "conditional_cc_toolchai
 
 conditional_cc_toolchain("cc-clang-linux-x86_64", "x86_64", False, %{absolute_paths})
 conditional_cc_toolchain("cc-clang-linux-aarch64", "aarch64", False, %{absolute_paths})
-conditional_cc_toolchain("cc-clang-darwin", "x86_64", True, %{absolute_paths})
+conditional_cc_toolchain("cc-clang-darwin-x86_64", "x86_64", True, %{absolute_paths})
+conditional_cc_toolchain("cc-clang-darwin-arm64", "arm64", True, %{absolute_paths})
 
 ## LLVM toolchain files
 # Needed when not using absolute paths.

--- a/toolchain/BUILD.tpl
+++ b/toolchain/BUILD.tpl
@@ -39,9 +39,11 @@ filegroup(
 cc_toolchain_suite(
     name = "toolchain",
     toolchains = {
-        "k8|clang": ":cc-clang-linux",
+        "k8|clang": ":cc-clang-linux-x86_64",
+        "aarch64|clang": ":cc-clang-linux-aarch64",
         "darwin|clang": ":cc-clang-darwin",
-        "k8": ":cc-clang-linux",
+        "k8": ":cc-clang-linux-x86_64",
+        "aarch64": ":cc-clang-linux-aarch64",
         "darwin": ":cc-clang-darwin",
     },
 )
@@ -49,8 +51,13 @@ cc_toolchain_suite(
 load(":cc_toolchain_config.bzl", "cc_toolchain_config")
 
 cc_toolchain_config(
-    name = "local_linux",
+    name = "local_linux-x86_64",
     cpu = "k8",
+)
+
+cc_toolchain_config(
+    name = "local_linux-aarch64",
+    cpu = "aarch64",
 )
 
 cc_toolchain_config(
@@ -73,7 +80,7 @@ toolchain(
 )
 
 toolchain(
-    name = "cc-toolchain-linux",
+    name = "cc-toolchain-linux-x86_64",
     exec_compatible_with = [
         "@platforms//cpu:x86_64",
         "@platforms//os:linux",
@@ -82,14 +89,29 @@ toolchain(
         "@platforms//cpu:x86_64",
         "@platforms//os:linux",
     ],
-    toolchain = ":cc-clang-linux",
+    toolchain = ":cc-clang-linux-x86_64",
+    toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
+)
+
+toolchain(
+    name = "cc-toolchain-linux-aarch64",
+    exec_compatible_with = [
+        "@platforms//cpu:aarch64",
+        "@platforms//os:linux",
+    ],
+    target_compatible_with = [
+        "@platforms//cpu:aarch64",
+        "@platforms//os:linux",
+    ],
+    toolchain = ":cc-clang-linux-aarch64",
     toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
 )
 
 load("@com_grail_bazel_toolchain//toolchain:rules.bzl", "conditional_cc_toolchain")
 
-conditional_cc_toolchain("cc-clang-linux", False, %{absolute_paths})
-conditional_cc_toolchain("cc-clang-darwin", True, %{absolute_paths})
+conditional_cc_toolchain("cc-clang-linux-x86_64", "x86_64", False, %{absolute_paths})
+conditional_cc_toolchain("cc-clang-linux-aarch64", "aarch64", False, %{absolute_paths})
+conditional_cc_toolchain("cc-clang-darwin", "x86_64", True, %{absolute_paths})
 
 ## LLVM toolchain files
 # Needed when not using absolute paths.

--- a/toolchain/cc_toolchain_config.bzl.tpl
+++ b/toolchain/cc_toolchain_config.bzl.tpl
@@ -160,7 +160,7 @@ def _impl(ctx):
             "-ldl",
             # Other linker flags.
             "-Wl,--build-id=md5",
-            "-Wl,--hash-style=gnu",
+            "-Wl,--hash-style=both",
             "-Wl,-z,relro,-z,now",
         ]
     elif ctx.attr.cpu == "darwin":

--- a/toolchain/cc_toolchain_config.bzl.tpl
+++ b/toolchain/cc_toolchain_config.bzl.tpl
@@ -255,10 +255,12 @@ def _impl(ctx):
                 actions = all_link_actions,
                 flag_groups = [
                     flag_group(
+                        # Explicitly specify the archive paths rather than using -L
+                        # so that the linker doesn't go poking around in toolchain_path_prefix
+                        # for libraries like libunwind -- at least by default.
                         flags = [
-                            "-L%{toolchain_path_prefix}/lib",
-                            "-lc++-static",
-                            "-lc++abi-static",
+                            "%{toolchain_path_prefix}/lib/libc++-static.a",
+                            "%{toolchain_path_prefix}/lib/libc++abi-static.a",
                         ],
                     ),
                 ],

--- a/toolchain/cc_toolchain_config.bzl.tpl
+++ b/toolchain/cc_toolchain_config.bzl.tpl
@@ -168,6 +168,9 @@ def _impl(ctx):
             "-headerpad_max_install_names",
             "-undefined",
             "dynamic_lookup",
+
+            # For Big Sur/Catalina compatibility
+            "-mlinker-version=400",
         ]
     else:
         fail("Unreachable")

--- a/toolchain/cc_toolchain_config.bzl.tpl
+++ b/toolchain/cc_toolchain_config.bzl.tpl
@@ -34,12 +34,16 @@ def _impl(ctx):
     if (ctx.attr.cpu == "darwin"):
         toolchain_identifier = "clang-darwin"
     elif (ctx.attr.cpu == "k8"):
-        toolchain_identifier = "clang-linux"
+        toolchain_identifier = "clang-linux-x86_64"
+    elif (ctx.attr.cpu == "aarch64"):
+        toolchain_identifier = "clang-linux-aarch64"
     else:
         fail("Unreachable")
 
     if (ctx.attr.cpu == "k8"):
         host_system_name = "x86_64"
+    elif (ctx.attr.cpu == "aarch64"):
+        host_system_name = "aarch64"
     elif (ctx.attr.cpu == "darwin"):
         host_system_name = "x86_64-apple-macosx"
     else:
@@ -49,6 +53,8 @@ def _impl(ctx):
         target_system_name = "x86_64-apple-macosx"
     elif (ctx.attr.cpu == "k8"):
         target_system_name = "x86_64-unknown-linux-gnu"
+    elif (ctx.attr.cpu == "aarch64"):
+        target_system_name = "aarch64-unknown-linux-gnu"
     else:
         fail("Unreachable")
 
@@ -56,10 +62,14 @@ def _impl(ctx):
         target_cpu = "darwin"
     elif (ctx.attr.cpu == "k8"):
         target_cpu = "k8"
+    elif (ctx.attr.cpu == "aarch64"):
+        target_cpu = "aarch64"
     else:
         fail("Unreachable")
 
     if (ctx.attr.cpu == "k8"):
+        target_libc = "glibc_unknown"
+    elif (ctx.attr.cpu == "aarch64"):
         target_libc = "glibc_unknown"
     elif (ctx.attr.cpu == "darwin"):
         target_libc = "macosx"
@@ -67,12 +77,15 @@ def _impl(ctx):
         fail("Unreachable")
 
     if (ctx.attr.cpu == "darwin" or
-        ctx.attr.cpu == "k8"):
+        ctx.attr.cpu == "k8" or
+        ctx.attr.cpu == "aarch64"):
         compiler = "clang"
     else:
         fail("Unreachable")
 
     if (ctx.attr.cpu == "k8"):
+        abi_version = "clang"
+    elif (ctx.attr.cpu == "aarch64"):
         abi_version = "clang"
     elif (ctx.attr.cpu == "darwin"):
         abi_version = "darwin_x86_64"
@@ -83,13 +96,16 @@ def _impl(ctx):
         abi_libc_version = "darwin_x86_64"
     elif (ctx.attr.cpu == "k8"):
         abi_libc_version = "glibc_unknown"
+    elif (ctx.attr.cpu == "aarch64"):
+        abi_libc_version = "glibc_unknown"
     else:
         fail("Unreachable")
 
     cc_target_os = None
 
     if (ctx.attr.cpu == "darwin" or
-        ctx.attr.cpu == "k8"):
+        ctx.attr.cpu == "k8" or
+        ctx.attr.cpu == "aarch64"):
         builtin_sysroot = "%{sysroot_path}"
     else:
         fail("Unreachable")
@@ -144,7 +160,7 @@ def _impl(ctx):
 
     action_configs = []
 
-    if ctx.attr.cpu == "k8":
+    if ctx.attr.cpu == "k8" or ctx.attr.cpu == "aarch64":
         linker_flags = [
             # Use the lld linker.
             "-fuse-ld=lld",
@@ -234,7 +250,7 @@ def _impl(ctx):
                 flag_groups = [flag_group(flags = ["-Wl,--gc-sections"])],
                 with_features = [with_feature_set(features = ["opt"])],
             ),
-        ] if ctx.attr.cpu == "k8" else []) + ([
+        ] if ctx.attr.cpu == "k8" or ctx.attr.cpu == "aarch64" else []) + ([
             flag_set(
                 actions = all_link_actions,
                 flag_groups = [
@@ -557,6 +573,14 @@ def _impl(ctx):
         ] + [
             %{k8_additional_cxx_builtin_include_directories}
         ]
+    elif (ctx.attr.cpu == "aarch64"):
+        cxx_builtin_include_directories += [
+            "%{sysroot_prefix}/include",
+            "%{sysroot_prefix}/usr/include",
+            "%{sysroot_prefix}/usr/local/include",
+        ] + [
+            %{aarch64_additional_cxx_builtin_include_directories}
+        ]
     elif (ctx.attr.cpu == "darwin"):
         cxx_builtin_include_directories += [
             "%{sysroot_prefix}/usr/include",
@@ -579,10 +603,12 @@ def _impl(ctx):
         ]
     elif (ctx.attr.cpu == "k8"):
         make_variables = []
+    elif (ctx.attr.cpu == "aarch64"):
+        make_variables = []
     else:
         fail("Unreachable")
 
-    if (ctx.attr.cpu == "k8"):
+    if (ctx.attr.cpu == "k8" or ctx.attr.cpu == "aarch64"):
         tool_paths = [
             tool_path(
                 name = "ld",
@@ -693,6 +719,7 @@ cc_toolchain_config = rule(
             values = [
                 "darwin",
                 "k8",
+                "aarch64"
             ],
         ),
     },

--- a/toolchain/cc_toolchain_config.bzl.tpl
+++ b/toolchain/cc_toolchain_config.bzl.tpl
@@ -563,6 +563,7 @@ def _impl(ctx):
 
     cxx_builtin_include_directories = [
         "%{toolchain_path_prefix}include/c++/v1",
+        "%{toolchain_path_prefix}include/{}/c++/v1".format(target_system_name),
         "%{toolchain_path_prefix}lib/clang/%{llvm_version}/include",
         "%{toolchain_path_prefix}/lib/clang/%{llvm_version}/share",
         "%{toolchain_path_prefix}lib64/clang/%{llvm_version}/include",

--- a/toolchain/cc_toolchain_config.bzl.tpl
+++ b/toolchain/cc_toolchain_config.bzl.tpl
@@ -31,8 +31,10 @@ load(
 load("@bazel_tools//tools/build_defs/cc:action_names.bzl", "ACTION_NAMES")
 
 def _impl(ctx):
-    if (ctx.attr.cpu == "darwin"):
-        toolchain_identifier = "clang-darwin"
+    if (ctx.attr.cpu == "darwin-x86_64"):
+        toolchain_identifier = "clang-darwin-x86_64"
+    elif (ctx.attr.cpu == "darwin-arm64"):
+        toolchain_identifier = "clang-darwin-arm64"
     elif (ctx.attr.cpu == "k8"):
         toolchain_identifier = "clang-linux-x86_64"
     elif (ctx.attr.cpu == "aarch64"):
@@ -44,13 +46,17 @@ def _impl(ctx):
         host_system_name = "x86_64"
     elif (ctx.attr.cpu == "aarch64"):
         host_system_name = "aarch64"
-    elif (ctx.attr.cpu == "darwin"):
+    elif (ctx.attr.cpu == "darwin-x86_64"):
         host_system_name = "x86_64-apple-macosx"
+    elif (ctx.attr.cpu == "darwin-arm64"):
+        host_system_name = "arm64-apple-macosx"
     else:
         fail("Unreachable")
 
-    if (ctx.attr.cpu == "darwin"):
+    if (ctx.attr.cpu == "darwin-x86_64"):
         target_system_name = "x86_64-apple-macosx"
+    elif (ctx.attr.cpu == "darwin-arm64"):
+        target_system_name = "arm64-apple-macosx"
     elif (ctx.attr.cpu == "k8"):
         target_system_name = "x86_64-unknown-linux-gnu"
     elif (ctx.attr.cpu == "aarch64"):
@@ -58,8 +64,10 @@ def _impl(ctx):
     else:
         fail("Unreachable")
 
-    if (ctx.attr.cpu == "darwin"):
-        target_cpu = "darwin"
+    if (ctx.attr.cpu == "darwin-x86_64"):
+        target_cpu = "darwin-x86_64"
+    elif (ctx.attr.cpu == "darwin-arm64"):
+        target_cpu = "darwin-arm64"
     elif (ctx.attr.cpu == "k8"):
         target_cpu = "k8"
     elif (ctx.attr.cpu == "aarch64"):
@@ -71,12 +79,15 @@ def _impl(ctx):
         target_libc = "glibc_unknown"
     elif (ctx.attr.cpu == "aarch64"):
         target_libc = "glibc_unknown"
-    elif (ctx.attr.cpu == "darwin"):
+    elif (ctx.attr.cpu == "darwin-x86_64"):
+        target_libc = "macosx"
+    elif (ctx.attr.cpu == "darwin-arm64"):
         target_libc = "macosx"
     else:
         fail("Unreachable")
 
-    if (ctx.attr.cpu == "darwin" or
+    if (ctx.attr.cpu == "darwin-x86_64" or
+        ctx.attr.cpu == "darwin-arm64" or
         ctx.attr.cpu == "k8" or
         ctx.attr.cpu == "aarch64"):
         compiler = "clang"
@@ -87,13 +98,17 @@ def _impl(ctx):
         abi_version = "clang"
     elif (ctx.attr.cpu == "aarch64"):
         abi_version = "clang"
-    elif (ctx.attr.cpu == "darwin"):
+    elif (ctx.attr.cpu == "darwin-x86_64"):
         abi_version = "darwin_x86_64"
+    elif (ctx.attr.cpu == "darwin-arm64"):
+        abi_version = "darwin_arm64"
     else:
         fail("Unreachable")
 
-    if (ctx.attr.cpu == "darwin"):
+    if (ctx.attr.cpu == "darwin-x86_64"):
         abi_libc_version = "darwin_x86_64"
+    elif (ctx.attr.cpu == "darwin-arm64"):
+        abi_libc_version = "darwin_arm64"
     elif (ctx.attr.cpu == "k8"):
         abi_libc_version = "glibc_unknown"
     elif (ctx.attr.cpu == "aarch64"):
@@ -103,7 +118,8 @@ def _impl(ctx):
 
     cc_target_os = None
 
-    if (ctx.attr.cpu == "darwin" or
+    if (ctx.attr.cpu == "darwin-x86_64" or
+        ctx.attr.cpu == "darwin-arm64" or
         ctx.attr.cpu == "k8" or
         ctx.attr.cpu == "aarch64"):
         builtin_sysroot = "%{sysroot_path}"
@@ -179,7 +195,7 @@ def _impl(ctx):
             "-Wl,--hash-style=both",
             "-Wl,-z,relro,-z,now",
         ]
-    elif ctx.attr.cpu == "darwin":
+    elif ctx.attr.cpu == "darwin-x86_64" or ctx.attr.cpu == "darwin-arm64":
         linker_flags = [
             "-headerpad_max_install_names",
             "-undefined",
@@ -286,7 +302,7 @@ def _impl(ctx):
                     ),
                 ],
             ),
-        ] if ctx.attr.cpu == "darwin" else []),
+        ] if ctx.attr.cpu == "darwin-x86_64" or ctx.attr.cpu == "darwin-arm64" else []),
     )
 
     default_compile_flags_feature = feature(
@@ -584,7 +600,7 @@ def _impl(ctx):
         ] + [
             %{aarch64_additional_cxx_builtin_include_directories}
         ]
-    elif (ctx.attr.cpu == "darwin"):
+    elif (ctx.attr.cpu == "darwin-x86_64" or ctx.attr.cpu == "darwin-arm64"):
         cxx_builtin_include_directories += [
             "%{sysroot_prefix}/usr/include",
             "%{sysroot_prefix}/System/Library/Frameworks",
@@ -597,7 +613,7 @@ def _impl(ctx):
 
     artifact_name_patterns = []
 
-    if (ctx.attr.cpu == "darwin"):
+    if (ctx.attr.cpu == "darwin-x86_64" or ctx.attr.cpu == "darwin-arm64"):
         make_variables = [
             make_variable(
                 name = "STACK_FRAME_UNLIMITED",
@@ -651,7 +667,7 @@ def _impl(ctx):
                 path = "%{tools_path_prefix}bin/llvm-ar",
             ),
         ]
-    elif (ctx.attr.cpu == "darwin"):
+    elif (ctx.attr.cpu == "darwin-x86_64" or ctx.attr.cpu == "darwin-arm64"):
         tool_paths = [
             tool_path(name = "ld", path = "%{tools_path_prefix}bin/ld"),
             tool_path(
@@ -720,7 +736,8 @@ cc_toolchain_config = rule(
         "cpu": attr.string(
             mandatory = True,
             values = [
-                "darwin",
+                "darwin-x86_64",
+                "darwin-arm64",
                 "k8",
                 "aarch64"
             ],

--- a/toolchain/cc_toolchain_config.bzl.tpl
+++ b/toolchain/cc_toolchain_config.bzl.tpl
@@ -543,6 +543,7 @@ def _impl(ctx):
     cxx_builtin_include_directories = [
         "%{toolchain_path_prefix}include/c++/v1",
         "%{toolchain_path_prefix}lib/clang/%{llvm_version}/include",
+        "%{toolchain_path_prefix}/lib/clang/%{llvm_version}/share",
         "%{toolchain_path_prefix}lib64/clang/%{llvm_version}/include",
     ]
     if (ctx.attr.cpu == "k8"):

--- a/toolchain/internal/configure.bzl
+++ b/toolchain/internal/configure.bzl
@@ -109,6 +109,9 @@ def llvm_register_toolchains():
     if not _download_llvm(rctx):
         _download_llvm_preconfigured(rctx)
 
+    rctx.execute(["cp", "lib/libc++.a", "lib/libc++-static.a"])
+    rctx.execute(["cp", "lib/libc++abi.a", "lib/libc++abi-static.a"])
+
 def conditional_cc_toolchain(name, darwin, absolute_paths = False):
     # Toolchain macro for BUILD file to use conditional logic.
 

--- a/toolchain/internal/configure.bzl
+++ b/toolchain/internal/configure.bzl
@@ -112,7 +112,6 @@ def llvm_register_toolchains():
 
     rctx.execute(["cp", "lib/libc++.a", "lib/libc++-static.a"])
     rctx.execute(["cp", "lib/libc++abi.a", "lib/libc++abi-static.a"])
-    rctx.execute(["rm", "-f", "lib/libunwind.dylib", "lib/libunwind.1.dylib", "lib/libunwind.1.0.dylib"])
 
 def conditional_cc_toolchain(name, cpu, darwin, absolute_paths = False):
     # Toolchain macro for BUILD file to use conditional logic.

--- a/toolchain/internal/configure.bzl
+++ b/toolchain/internal/configure.bzl
@@ -112,6 +112,7 @@ def llvm_register_toolchains():
 
     rctx.execute(["cp", "lib/libc++.a", "lib/libc++-static.a"])
     rctx.execute(["cp", "lib/libc++abi.a", "lib/libc++abi-static.a"])
+    rctx.execute(["rm", "-f", "lib/libunwind.dylib", "lib/libunwind.1.dylib", "lib/libunwind.1.0.dylib"])
 
 def conditional_cc_toolchain(name, cpu, darwin, absolute_paths = False):
     # Toolchain macro for BUILD file to use conditional logic.

--- a/toolchain/internal/configure.bzl
+++ b/toolchain/internal/configure.bzl
@@ -65,6 +65,7 @@ def llvm_register_toolchains():
         "%{absolute_paths}": "True" if rctx.attr.absolute_paths else "False",
         "%{makevars_ld_flags}": _makevars_ld_flags(rctx),
         "%{k8_additional_cxx_builtin_include_directories}": _include_dirs_str(rctx, "k8"),
+        "%{aarch64_additional_cxx_builtin_include_directories}": _include_dirs_str(rctx, "aarch64"),
         "%{darwin_additional_cxx_builtin_include_directories}": _include_dirs_str(rctx, "darwin"),
     }
 
@@ -112,11 +113,11 @@ def llvm_register_toolchains():
     rctx.execute(["cp", "lib/libc++.a", "lib/libc++-static.a"])
     rctx.execute(["cp", "lib/libc++abi.a", "lib/libc++abi-static.a"])
 
-def conditional_cc_toolchain(name, darwin, absolute_paths = False):
+def conditional_cc_toolchain(name, cpu, darwin, absolute_paths = False):
     # Toolchain macro for BUILD file to use conditional logic.
 
-    toolchain_config = "local_darwin" if darwin else "local_linux"
-    toolchain_identifier = "clang-darwin" if darwin else "clang-linux"
+    toolchain_config = "local_darwin" if darwin else ("local_linux-%s" % cpu)
+    toolchain_identifier = "clang-darwin" if darwin else ("clang-linux-%s" % cpu)
 
     if absolute_paths:
         _cc_toolchain(

--- a/toolchain/internal/configure.bzl
+++ b/toolchain/internal/configure.bzl
@@ -116,8 +116,8 @@ def llvm_register_toolchains():
 def conditional_cc_toolchain(name, cpu, darwin, absolute_paths = False):
     # Toolchain macro for BUILD file to use conditional logic.
 
-    toolchain_config = "local_darwin" if darwin else ("local_linux-%s" % cpu)
-    toolchain_identifier = "clang-darwin" if darwin else ("clang-linux-%s" % cpu)
+    toolchain_config = "local_darwin-x86_64" if darwin else ("local_linux-%s" % cpu)
+    toolchain_identifier = "clang-darwin-x86_64" if darwin else ("clang-linux-%s" % cpu)
 
     if absolute_paths:
         _cc_toolchain(

--- a/toolchain/internal/llvm_distributions.bzl
+++ b/toolchain/internal/llvm_distributions.bzl
@@ -120,6 +120,18 @@ _llvm_distributions = {
     "clang+llvm-11.0.0-x86_64-linux-gnu-ubuntu-20.04.tar.xz": "829f5fb0ebda1d8716464394f97d5475d465ddc7bea2879c0601316b611ff6db",
     "clang+llvm-11.0.0-amd64-pc-solaris2.11.tar.xz": "031699337d703fe42843a8326f94079fd67e46b60f25be5bdf47664e158e0b43",
     "clang+llvm-11.0.0-x86_64-apple-darwin.tar.xz": "b93886ab0025cbbdbb08b46e5e403a462b0ce034811c929e96ed66c2b07fe63a",
+
+    # 12.0.0
+    "clang+llvm-12.0.0-armv7a-linux-gnueabihf.tar.xz": "697d432c2572e48fc04118fc7cec63c9477ef2e8a7cca2c0b32e52f9705ab1cc",
+    "clang+llvm-12.0.0-i386-unknown-freebsd11.tar.xz": "8298a026f74165bf6088c1c942c22bd7532b12cd2b916f7673bdaf522abe41b0",
+    "clang+llvm-12.0.0-x86_64-apple-darwin.tar.xz": "7bc2259bf75c003f644882460fc8e844ddb23b27236fe43a2787870a4cd8ab50",
+    "clang+llvm-12.0.0-amd64-unknown-freebsd11.tar.xz": "8ff2ae0863d4cbe88ace6cbcce64a1a6c9a8f1237f635125a5d580b2639bba61",
+    "clang+llvm-12.0.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz": "9694f4df031c614dbe59b8431f94c68631971ad44173eecc1ea1a9e8ee27b2a3",
+    "clang+llvm-12.0.0-aarch64-linux-gnu.tar.xz": "d05f0b04fb248ce1e7a61fcd2087e6be8bc4b06b2cc348792f383abf414dec48",
+    "clang+llvm-12.0.0-amd64-unknown-freebsd12.tar.xz": "0a90d2cf8a3d71d7d4a6bee3e085405ebc37a854311bce82d6845d93b19fcc87",
+    "clang+llvm-12.0.0-x86_64-linux-sles12.4.tar.xz": "00c25261e303080c2e8d55413a73c60913cdb39cfd47587d6817a86fe52565e9",
+    "clang+llvm-12.0.0-i386-unknown-freebsd12.tar.xz": "1e61921735fd11754df193826306f0352c99ca6013e22f40a7fc77f0b20162be",
+    "clang+llvm-12.0.0-x86_64-linux-gnu-ubuntu-20.04.tar.xz": "a9ff205eb0b73ca7c86afc6432eed1c2d49133bd0d49e47b15be59bbf0dd292e",
 }
 
 # Note: Unlike the user-specified llvm_mirror attribute, the URL prefixes in
@@ -135,6 +147,7 @@ _llvm_distributions_base_url = {
     "10.0.0": "https://github.com/llvm/llvm-project/releases/download/llvmorg-",
     "10.0.1": "https://github.com/llvm/llvm-project/releases/download/llvmorg-",
     "11.0.0": "https://github.com/llvm/llvm-project/releases/download/llvmorg-",
+    "12.0.0": "https://github.com/llvm/llvm-project/releases/download/llvmorg-",
 }
 
 def _python(rctx):

--- a/toolchain/internal/llvm_distributions.bzl
+++ b/toolchain/internal/llvm_distributions.bzl
@@ -151,6 +151,296 @@ _llvm_distributions = {
     "clang+llvm-13.0.0-x86_64-apple-darwin.tar.xz": "d051234eca1db1f5e4bc08c64937c879c7098900f7a0370f3ceb7544816a8b09",
     "clang+llvm-13.0.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz": "76d0bf002ede7a893f69d9ad2c4e101d15a8f4186fbfe24e74856c8449acd7c1",
     "clang+llvm-13.0.0-x86_64-linux-gnu-ubuntu-20.04.tar.xz": "2c2fb857af97f41a5032e9ecadf7f78d3eff389a5cd3c9ec620d24f134ceb3c8",
+
+    # 13.0.1
+    "clang+llvm-13.0.1-aarch64-linux-gnu.tar.xz": "15ff2db12683e69e552b6668f7ca49edaa01ce32cb1cbc8f8ed2e887ab291069",
+    "clang+llvm-13.0.1-amd64-unknown-freebsd12.tar.xz": "8101c8d3a920bf930b33987ada5373f43537c5de8c194be0ea10530fd0ad5617",
+    "clang+llvm-13.0.1-amd64-unknown-freebsd13.tar.xz": "f1ba8ec77b5e82399af738ad9897a8aafc11c5692ceb331c8373eae77018d428",
+    "clang+llvm-13.0.1-armv7a-linux-gnueabihf.tar.xz": "1215720114538f57acbe2f3b0614c23f4fc551ba2976afa3779a3c01aaaf1221",
+    "clang+llvm-13.0.1-i386-unknown-freebsd12.tar.xz": "e3c921e0f130afa6a6ebac23c31b66b32563a5ec53a2f4ed4676f31a81379f70",
+    "clang+llvm-13.0.1-i386-unknown-freebsd13.tar.xz": "e85c46bd64a0217f3df1f42421a502648d6741ef29fd5d44674b87af119ce25d",
+    "clang+llvm-13.0.1-powerpc64le-linux-rhel-7.9.tar.xz": "ab659c290536182a99c064d4537d2fb1273bb2b1bf8c6a43866f033bf1ece4a8",
+    "clang+llvm-13.0.1-powerpc64le-linux-ubuntu-18.04.5.tar.xz": "7a4be2508aa0b4ee3f72c312af4b62ea14581a5db61aa703ea0822f46e5598cb",
+    "clang+llvm-13.0.1-x86_64-apple-darwin.tar.xz": "dec02d17698514d0fc7ace8869c38937851c542b02adf102c4e898f027145a4d",
+    "clang+llvm-13.0.1-x86_64-linux-gnu-ubuntu-18.04.tar.xz": "84a54c69781ad90615d1b0276a83ff87daaeded99fbc64457c350679df7b4ff0",
+
+    # 14.0.0
+    "clang+llvm-14.0.0-aarch64-linux-gnu.tar.xz": "1792badcd44066c79148ffeb1746058422cc9d838462be07e3cb19a4b724a1ee",
+    "clang+llvm-14.0.0-amd64-pc-solaris2.11.tar.xz": "a708470fdbaadf530d6cfd56f92fde1328cb47ef8439ecf1a2126523e7c94a50",
+    "clang+llvm-14.0.0-amd64-unknown-freebsd12.tar.xz": "7eaff7ee2a32babd795599f41f4a5ffe7f161721ebf5630f48418e626650105e",
+    "clang+llvm-14.0.0-amd64-unknown-freebsd13.tar.xz": "b68d73fd57be385e7f06046a87381f7520c8861f492c294e6301d2843d9a1f57",
+    "clang+llvm-14.0.0-armv7a-linux-gnueabihf.tar.xz": "17d5f60c3d5f9494be7f67b2dc9e6017cd5e8457e53465968a54ec7069923bfe",
+    "clang+llvm-14.0.0-i386-unknown-freebsd12.tar.xz": "5ed9d93a8425132e8117d7061d09c2989ce6b2326f25c46633e2b2dee955bb00",
+    "clang+llvm-14.0.0-i386-unknown-freebsd13.tar.xz": "81f49eb466ce9149335ac8918a5f02fa724d562a94464ed13745db0165b4a220",
+    "clang+llvm-14.0.0-powerpc64-ibm-aix-7.2.tar.xz": "4ad5866de6c69d989cbbc989201b46dfdcd7d2b23a712fcad7baa09c204f10de",
+    "clang+llvm-14.0.0-powerpc64le-linux-rhel-7.9.tar.xz": "7a31de37959fdf3be897b01f284a91c28cd38a2e2fa038ff58121d1b6f6eb087",
+    "clang+llvm-14.0.0-powerpc64le-linux-ubuntu-18.04.tar.xz": "2d504c4920885c86b306358846178bc2232dfac83b47c3b1d05861a8162980e6",
+    "clang+llvm-14.0.0-sparcv9-sun-solaris2.11.tar.xz": "b342cdaaea3b44de5b0f45052e2df49bcdf69dcc8ad0c23ec5afc04668929681",
+    "clang+llvm-14.0.0-x86_64-apple-darwin.tar.xz": "cf5af0f32d78dcf4413ef6966abbfd5b1445fe80bba57f2ff8a08f77e672b9b3",
+    "clang+llvm-14.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz": "61582215dafafb7b576ea30cc136be92c877ba1f1c31ddbbd372d6d65622fef5",
+    "clang+llvm-14.0.0-x86_64-linux-sles12.4.tar.xz": "78f70cc94c3b6f562455b15cebb63e75571d50c3d488d53d9aa4cd9dded30627",
+
+    # 14.0.1
+    "clang+llvm-14.0.1-aarch64-linux-gnu.tar.xz": "0f1fe0c927ebc2fc9e7d55188b80cd4982e49ae2a667bff1199435fb21159f52",
+    "clang+llvm-14.0.1-amd64-pc-solaris2.11.tar.xz": "220c3f690a6e7ca2fb180594071d39556a4ea0951672397c9f5946656f088956",
+    "clang+llvm-14.0.1-amd64-unknown-freebsd12.tar.xz": "755023705bb7caa9db3f06c02908f840612a1497da4da617d1022522a978f4de",
+    "clang+llvm-14.0.1-amd64-unknown-freebsd13.tar.xz": "657497b3525b9ae115a019bb5ea401f198e087761f17155f4335a5df1f6994df",
+    "clang+llvm-14.0.1-armv7a-linux-gnueabihf.tar.xz": "be17b515b4a7938959ada101ca72fd9f59faf605e5838211e8915a36bf68f0d5",
+    "clang+llvm-14.0.1-powerpc64-ibm-aix-7.2.tar.xz": "0426b0b87c6275436f8285f4998f5588139405d61a3d5edc64c88119b57f4ebf",
+    "clang+llvm-14.0.1-powerpc64le-linux-rhel-8.4.tar.xz": "222238faa88a46b65a0610923bb27ab357e7eb1ac3f894c89c0b474b516da4bf",
+    "clang+llvm-14.0.1-powerpc64le-linux-ubuntu-18.04.tar.xz": "761e8a3ce4efa6ee4e98f777b34a5fd7db64a1e0baf8c6eab51c078d646e567f",
+    "clang+llvm-14.0.1-sparcv9-sun-solaris2.11.tar.xz": "ba2e06fda8e0c5eb7daec3159b43ac1b41a9ef6a576cab772b0bc5bfc3ba5851",
+    "clang+llvm-14.0.1-x86_64-apple-darwin.tar.xz": "43149390e95b1cdbf1d4ef2e9d214bbb6d35858ceb2df27245868e06bc4fc44c",
+
+    # 14.0.2
+    "clang+llvm-14.0.2-aarch64-linux-gnu.tar.xz": "ad6d065a2cf1c67698cc7f368722b1adc3fa2d7c9401446f0046612b6c90edc4",
+    "clang+llvm-14.0.2-amd64-unknown-freebsd12.tar.xz": "1df946b25963e941253e2aad31c92979630af9b12fc8be2538e191013a151bb1",
+    "clang+llvm-14.0.2-amd64-unknown-freebsd13.tar.xz": "0acab62c60dfb7449cd635000300feeff19717a14056d33a90c0b33fd0ffcb01",
+    "clang+llvm-14.0.2-powerpc64-ibm-aix-7.2.tar.xz": "837482b5ca8f144365bd1810910cbce39d0d3c4c97a8aa4ac8612d0ffb248407",
+    "clang+llvm-14.0.2-x86_64-apple-darwin.tar.xz": "7037efca192eb04a569a7422bd5d974a0af315b979252b6d956d2657ac33d672",
+
+    # 14.0.3
+    "clang+llvm-14.0.3-aarch64-linux-gnu.tar.xz": "36958cf3f1be9e91f33b0ce86afe049c2cf89c320996f963ee232c2405a811ec",
+    "clang+llvm-14.0.3-amd64-unknown-freebsd12.tar.xz": "62737fb1da58af725c0c93015c5d8250a723d976e8d7ef26b6445f8cb23c4f91",
+    "clang+llvm-14.0.3-amd64-unknown-freebsd13.tar.xz": "2c8d9537af54626395a3dbd0aa7ccd2c76aab567507a8293ab75967ab784162d",
+    "clang+llvm-14.0.3-armv7a-linux-gnueabihf.tar.xz": "2279cd46a7b619a0cb66d54012917c889e37c56f718ab92813dc13131f2fd805",
+    "clang+llvm-14.0.3-powerpc64-ibm-aix-7.2.tar.xz": "2afa547a182248a36815f31a427faced639286881bc975804563994e6c962552",
+    "clang+llvm-14.0.3-powerpc64le-linux-rhel-8.4.tar.xz": "6c2d79cebec1a0ba96c13bca613b01b7ebf194fcbd0ecf4d3432d4a7804e71ff",
+    "clang+llvm-14.0.3-powerpc64le-linux-ubuntu-18.04.tar.xz": "5ae686c74ab0b9b2930861c0d2875fcd4db22a9c6bdd9c9507120a0f808c17c8",
+    "clang+llvm-14.0.3-x86_64-apple-darwin.tar.xz": "90e07966dbaf87de0cbb206ab763023f9c559612c91d43a1711af7dc026cfb81",
+
+    # 14.0.4
+    "clang+llvm-14.0.4-aarch64-linux-gnu.tar.xz": "0c960d50c83360d81e698120f131cf004676cbe5ac6db6fbe67a0950f3cde2d1",
+    "clang+llvm-14.0.4-amd64-unknown-freebsd12.tar.xz": "80814b7a7a56151b204aa8cb621df22c645f41c834920c3818d6b6eadb175a79",
+    "clang+llvm-14.0.4-amd64-unknown-freebsd13.tar.xz": "282696627bb3f2d07dd38d7c67ecff97877f2b984d712dbcb506e3f0a63ad1f8",
+    "clang+llvm-14.0.4-armv7a-linux-gnueabihf.tar.xz": "09bb79557235aee16badc4e3db86a121b0b3c7af226e093c908a1c66c5a0c4c4",
+    "clang+llvm-14.0.4-powerpc64-ibm-aix-7.2.tar.xz": "2af35c3e1b60f68551cd92a31b66c6ad9b2986e9cb3f2aa924e225ae254d1a46",
+    "clang+llvm-14.0.4-powerpc64le-linux-rhel-8.4.tar.xz": "0c35b2ebd22c081d19679889e4afedf2060f1649d1060d45e0fa00f61dfba542",
+    "clang+llvm-14.0.4-powerpc64le-linux-ubuntu-18.04.5.tar.xz": "5736642965dca707282e22d084e3ec621f0fc8db8779e82f8d667942112bdac6",
+    "clang+llvm-14.0.4-x86_64-apple-darwin.tar.xz": "f6d9801b0bd78479229d21e2d5650c5a61f9ab1b6f80bad0dccf4b7a7eb30abf",
+
+    # 14.0.5
+    "clang+llvm-14.0.5-aarch64-linux-gnu.tar.xz": "e8138f24d716ef9714e259ab276e6ef74c8adcf9af0270464a8a01c24a583ea8",
+    "clang+llvm-14.0.5-amd64-unknown-freebsd12.tar.xz": "1edee096aa23e2c0b75352953c4f04a105fd9521de6742d4652b44ab9009636c",
+    "clang+llvm-14.0.5-amd64-unknown-freebsd13.tar.xz": "52c62e29f2cd8d72d592cded337e47bb8cb0998f7ee5f3c1b168790bdce154e7",
+    "clang+llvm-14.0.5-armv7a-linux-gnueabihf.tar.xz": "f80dbd2684f8fe13ce675236e5ef0235fdf5239d442c21f066245d7fb98ba11c",
+    "clang+llvm-14.0.5-powerpc64-ibm-aix-7.2.tar.xz": "8b2dd8fb508d295cf72be84a592a3592824fd4d881a9fcd6c2a64ba4954fe944",
+    "clang+llvm-14.0.5-powerpc64le-linux-rhel-8.4.tar.xz": "003314da4c23996f4fb40590e152ec2f42cd2c9ad71d70be68fcc76a746cb093",
+    "clang+llvm-14.0.5-powerpc64le-linux-ubuntu-18.04.5.tar.xz": "8d4bfe5cd53515adde095f07395356d71287a6ff27fa3e2219850b865f19d113",
+    "clang+llvm-14.0.5-x86_64-apple-darwin.tar.xz": "66cf1b8e00289a567b2f5f740f068b7682e27ccf048647b836d3624376a64705",
+
+    # 14.0.6
+    "clang+llvm-14.0.6-aarch64-linux-gnu.tar.xz": "1a81fda984f5e607584916fdf69cf41e5385b219b983544d2c1a14950d5a65cf",
+    "clang+llvm-14.0.6-amd64-unknown-freebsd12.tar.xz": "b0a7b86dacb12afb8dd2ca99ea1b894d9cce84aab7711cb1964b3005dfb09af3",
+    "clang+llvm-14.0.6-amd64-unknown-freebsd13.tar.xz": "503e806ae67323c4f790ea2b1fe21e52809814d6a51263e2618f0c22ec47f6ff",
+    "clang+llvm-14.0.6-arm64-apple-darwin22.3.0.tar.xz": "82f4f7607a16c9aaf7314b945bde6a4639836ec9d2b474ebb3a31dee33e3c15a",
+    "clang+llvm-14.0.6-armv7a-linux-gnueabihf.tar.xz": "e50243c191334b80faa0bb18bbadb8afa35cd3d19cb521353c666c1a7ef20173",
+    "clang+llvm-14.0.6-powerpc64-ibm-aix-7.2.tar.xz": "38af6625848a8343dc834c2a272ba88028efab575681d913a39a3c6eaa3c11dc",
+    "clang+llvm-14.0.6-powerpc64le-linux-rhel-8.4.tar.xz": "4ef7c608ac026bca64149e59fb3abfe0f5212f2be0af12fe6e52c9413b1f7c4a",
+    "clang+llvm-14.0.6-powerpc64le-linux-ubuntu-18.04.5.tar.xz": "5eaff8c40a94d36336221f31b413fba500ec240403fa12e99dd49b56b736eeb3",
+    "clang+llvm-14.0.6-x86_64-apple-darwin.tar.xz": "e6cc6b8279661fd4452c2847cb8e55ce1e54e1faf4ab497b37c85ffdb6685e7c",
+    "clang+llvm-14.0.6-x86_64-linux-gnu-rhel-8.4.tar.xz": "7412026be8bb8f6b4c25ef58c7a1f78ed5ea039d94f0fa633a386de9c60a6942",
+
+    # 15.0.0
+    "clang+llvm-15.0.0-aarch64-linux-gnu.tar.xz": "527ed550784681f95ec7a1be8fbf5a24bd03d7da9bf31afb6523996f45670be3",
+    "clang+llvm-15.0.0-amd64-pc-solaris2.11.tar.xz": "5b9fd6a30ce6941adf74667d2076a49aa047fa040e3690f7af26c264d4ce58e7",
+    "clang+llvm-15.0.0-arm64-apple-darwin21.0.tar.xz": "cfd5c3fa07d7fccea0687f5b4498329a6172b7a15bbc45b547d0ac86bd3452a5",
+    "clang+llvm-15.0.0-armv7a-linux-gnueabihf.tar.xz": "58ce8877642fc1399736ffc81bc8ef6244440fc78d72e097a07475b8b25e2bf1",
+    "clang+llvm-15.0.0-powerpc64-ibm-aix-7.2.tar.xz": "c5f63401fa88ea96ca7110bd81ead1bf1a2575962e9cc84a6713ec29c02b1c10",
+    "clang+llvm-15.0.0-powerpc64le-linux-rhel-8.4.tar.xz": "c94448766b6b92cfc8f35e611308c9680a9ad2177f88d358c2b06e9b108d61bd",
+    "clang+llvm-15.0.0-powerpc64le-linux-ubuntu-18.04.6.tar.xz": "6bcedc3d18552732f219c1d0f8c4b0c917ff5f800400a31dabfe8d040cbf1f02",
+    "clang+llvm-15.0.0-sparc64-unknown-linux-gnu.tar.xz": "b5a8108040d5d5d69d6106fa89a6cffc71a16a3583b74c1f15c42f392a47a3d9",
+    "clang+llvm-15.0.0-sparcv9-sun-solaris2.11.tar.xz": "4354854976355ca6f4ac90231a97121844c4fc9f998c9850527390120c62f01f",
+    "clang+llvm-15.0.0-x86_64-apple-darwin.tar.xz": "8fb11e6ada98b901398b2e7b0378a3a59e88c88c754e95d8f6b54613254d7d65",
+    "clang+llvm-15.0.0-x86_64-linux-gnu-rhel-8.4.tar.xz": "20b17fabc97b93791098e771adf18013c50eae2e45407f8bfa772883b6027d30",
+
+    # 15.0.1
+    "clang+llvm-15.0.1-aarch64-linux-gnu.tar.xz": "201b2f5e537ec88937e0e1b30512453076e73a06ca75edf9939dc0e61b5ccbd1",
+    "clang+llvm-15.0.1-arm64-apple-darwin21.0.tar.xz": "858f86d96b5e4880f69f7a583daddbf97ee94e7cffce0d53aa05cba6967f13b8",
+    "clang+llvm-15.0.1-armv7a-linux-gnueabihf.tar.xz": "d145a2458a11b3977e48b3fbce66a70d88acd148a44fbf22c0c7a53fb27218bb",
+    "clang+llvm-15.0.1-powerpc64-ibm-aix-7.2.tar.xz": "0ee72558ba052815f64f112bdebc6b1684c3cf868ed588936e23ef3bdc52d216",
+    "clang+llvm-15.0.1-powerpc64le-linux-rhel-8.4.tar.xz": "30895fae1cdf5cb11ce5fa14fb2e2c16476f1f94c731bf3de398c79be64fed70",
+    "clang+llvm-15.0.1-powerpc64le-linux-ubuntu-18.04.5.tar.xz": "e7c427e0590e8c362d0766f9125674e847be9d30986c3d6928be960b30c87e63",
+    "clang+llvm-15.0.1-x86_64-apple-darwin.tar.xz": "0b2f1a811e68d011344103274733b7670c15bbe08b2a3a5140ccad8e19d9311e",
+
+    # 15.0.2
+    "clang+llvm-15.0.2-aarch64-linux-gnu.tar.xz": "3d0c2b28b0c06ebb9e0ce75e337680403771b28a4b8f065ce608cf2386f97a73",
+    "clang+llvm-15.0.2-arm64-apple-darwin21.0.tar.xz": "8c33f807bca56568b7060d0474daf63c8c10ec521d8188ac76362354d313ec58",
+    "clang+llvm-15.0.2-powerpc64-ibm-aix-7.2.tar.xz": "7c040d47745923fd8d7fffdd0d37587b021165f1fcc76015e56adbd2f427b251",
+    "clang+llvm-15.0.2-powerpc64le-linux-rhel-8.4.tar.xz": "c35d4a36baf1fe2ba790c5813e7d9efa60f892e08f5778d8ba2a1b0092fb9c1c",
+    "clang+llvm-15.0.2-powerpc64le-linux-ubuntu-18.04.5.tar.xz": "eeef0714f4ef208f45c757514d1b40114c2ac54bb5885d96b306d50f7725f1cf",
+    "clang+llvm-15.0.2-x86_64-apple-darwin.tar.xz": "a37ec6204f555605fa11e9c0e139a251402590ead6e227fc72da193e03883882",
+    "clang+llvm-15.0.2-x86_64-unknown-linux-gnu-rhel86.tar.xz": "f48f479e91ee7297ed8306c9d4495015691237cd91cc5330d3e1ee057b0548bd",
+    "clang+llvm-15.0.2-x86_64-unknown-linux-gnu-sles15.tar.xz": "8af00fb689459cb6b9af2a427af9d7d99da8f77e1da161fa1dc58164832b3b21",
+
+    # 15.0.3
+    "clang+llvm-15.0.3-aarch64-linux-gnu.tar.xz": "fa59fad997025da49b5001d6dc193bb7899e59de6268406b76c4fdbe2b56b7fd",
+    "clang+llvm-15.0.3-arm64-apple-darwin21.0.tar.xz": "83603b1258995f2659c3a87f7f62ee9b9c9775d7c7cde92a375c635f7bf73c28",
+    "clang+llvm-15.0.3-armv7a-linux-gnueabihf.tar.xz": "6de24c0f778d14228fe15908c687dc7caba280c688d61cc55cbb8d74551385de",
+    "clang+llvm-15.0.3-powerpc64-ibm-aix-7.2.tar.xz": "b4fed7e95d33922140e2e080a4b41a7b69b4a7bbcbaa5d896b578d57013639f0",
+    "clang+llvm-15.0.3-powerpc64le-linux-rhel-8.4.tar.xz": "5f26ddae25d8d742fc33c85393e4890df37aa16d25d174708de94555b93e3ab3",
+    "clang+llvm-15.0.3-powerpc64le-linux-ubuntu-18.04.5.tar.xz": "a5b558266eb0ad11c7db1358763e2ad7194dd7403919a76b444d7a6619ede86a",
+    "clang+llvm-15.0.3-x86_64-apple-darwin.tar.xz": "ac668586b2b3d068f1e43520a3ef0b1592e5dc3eff1a4a4b772e29803b428a69",
+
+    # 15.0.4
+    "clang+llvm-15.0.4-arm64-apple-darwin21.0.tar.xz": "70e7a6d98fc42d4c36aca1a5b666c57e83ae474df5920382853b9209c829938a",
+    "clang+llvm-15.0.4-powerpc64-ibm-aix-7.2.tar.xz": "c0aa0323c0705b93b89667aa8f34ae46e40a6da092295d21895fd7b866ce7f5d",
+    "clang+llvm-15.0.4-powerpc64le-linux-rhel-8.4.tar.xz": "4209982861e11852d2248daba76239182d82d1e2165927da12cdbd603d0ec421",
+    "clang+llvm-15.0.4-powerpc64le-linux-ubuntu-18.04.5.tar.xz": "0f90e85c21c54d482d3c0ecd073671938d209e5fe8392bb72668cca179b92fd6",
+    "clang+llvm-15.0.4-x86_64-apple-darwin.tar.xz": "4c98d891c07c8f6661b233bf6652981f28432cfdbd6f07181114195c3536544b",
+    "clang+llvm-15.0.4-x86_64-linux-gnu-rhel-8.4.tar.xz": "2672e88fc9c79ff287a0d0e6dbbaf77fbbea3c12dab39fd733ae9432fbcb7e9e",
+
+    # 15.0.5
+    "clang+llvm-15.0.5-arm64-apple-darwin21.0.tar.xz": "0fda3ef24071dffb0c95378be7ed4114999a5a169cd61015e489fd6ee8406809",
+    "clang+llvm-15.0.5-powerpc64-ibm-aix-7.2.tar.xz": "eeb3efa22e0bede117474700fd72cf4e4aa0b221401e42e172773740d56635b2",
+    "clang+llvm-15.0.5-powerpc64le-linux-rhel-8.4.tar.xz": "b27ec77eea47c1403e66726c97fa2f3c9dd19d40606aa195ff2382f09959253b",
+    "clang+llvm-15.0.5-powerpc64le-linux-ubuntu-18.04.5.tar.xz": "760ab1e879438659abeecfed2f08701e996ea02bcdb83d618ccf9390f59f6882",
+    "clang+llvm-15.0.5-x86_64-linux-gnu-ubuntu-18.04.tar.xz": "15018e4f45889450b62367acbdc7628556ceba92bd9f6b0544145334d1311cbc",
+
+    # 15.0.6
+    "clang+llvm-15.0.6-aarch64-linux-gnu.tar.xz": "8ca4d68cf103da8331ca3f35fe23d940c1b78fb7f0d4763c1c059e352f5d1bec",
+    "clang+llvm-15.0.6-arm64-apple-darwin21.0.tar.xz": "32bc7b8eee3d98f72dd4e5651e6da990274ee2d28c5c19a7d8237eb817ce8d91",
+    "clang+llvm-15.0.6-armv7a-linux-gnueabihf.tar.xz": "c12e9298f9a9ed3a96342e9ffb2c02146a0cd7535231fef57c7217bd3a36f53b",
+    "clang+llvm-15.0.6-powerpc64-ibm-aix-7.2.tar.xz": "6bc1c2fcc8069e28773f6a0d16624160cd6de01b8f15aab27652eedad665d462",
+    "clang+llvm-15.0.6-powerpc64le-linux-rhel-8.4.tar.xz": "c26e5563e6ff46a03bc45fe27547c69283b64cba2359ccd3a42f735c995c0511",
+    "clang+llvm-15.0.6-powerpc64le-linux-ubuntu-18.04.tar.xz": "7fc9f07ff0fcf191df93fe4adc1da555e43f62fe1d3ddafb15c943f72b1bda17",
+    "clang+llvm-15.0.6-x86_64-linux-gnu-ubuntu-18.04.tar.xz": "38bc7f5563642e73e69ac5626724e206d6d539fbef653541b34cae0ba9c3f036",
+
+    # 15.0.7
+    "clang+llvm-15.0.7-arm64-apple-darwin22.0.tar.xz": "867c6afd41158c132ef05a8f1ddaecf476a26b91c85def8e124414f9a9ba188d",
+    "clang+llvm-15.0.7-powerpc64-ibm-aix-7.2.tar.xz": "6cbc7c7f4395abb9c1a5bdcab3811bd6b1a6c4d08756ba674bfbbd732e2b23ac",
+    "clang+llvm-15.0.7-powerpc64le-linux-rhel-8.4.tar.xz": "2163cc934437146dc30810a21a46327ba3983f123c3bea19be316a64135b6414",
+    "clang+llvm-15.0.7-powerpc64le-linux-ubuntu-18.04.tar.xz": "19a16d768e15966923b0cbf8fc7dc148c89e316857acd89ad3aff72dcfcd61f4",
+    "clang+llvm-15.0.7-x86_64-apple-darwin21.0.tar.xz": "d16b6d536364c5bec6583d12dd7e6cf841b9f508c4430d9ee886726bd9983f1c",
+    # -- Built by Stripe, not upstream --
+    "clang+llvm-15.0.7-x86_64-linux-gnu-ubuntu-20.04.tar.xz": "3393c29279aea207996d816c7f5a6ddecf3451ab31242319b716e3ea074efdac",
+    "clang+llvm-15.0.7-aarch64-linux-gnu.tar.xz": "b51ec9632c5b6d25bb1da159fe2f06d3e72b1667343f1921e99966800ead8a9a",
+
+    # 16.0.0
+    "clang+llvm-16.0.0-aarch64-linux-gnu.tar.xz": "b750ba3120e6153fc5b316092f19b52cf3eb64e19e5f44bd1b962cb54a20cf0a",
+    "clang+llvm-16.0.0-amd64-pc-solaris2.11.tar.xz": "b637b7da383d3417ac4862342911cb467fba2ec00f48f163eb8308f2bbb9b7ad",
+    "clang+llvm-16.0.0-amd64-unknown-freebsd13.tar.xz": "c4fe6293349b3ab7d802793103d1d44f58831884e63ff1b40ce29c3e7408257b",
+    "clang+llvm-16.0.0-arm64-apple-darwin22.0.tar.xz": "2041587b90626a4a87f0de14a5842c14c6c3374f42c8ed12726ef017416409d9",
+    "clang+llvm-16.0.0-powerpc64-ibm-aix-7.2.tar.xz": "e51209eeea3c3db41084d8625ab3357991980831e0b641d633ec23e9d858333f",
+    "clang+llvm-16.0.0-powerpc64le-linux-rhel-8.4.tar.xz": "eb56949af9a83a12754f7cf254886d30c4be8a1da4dd0f27db790a7fcd35a3bf",
+    "clang+llvm-16.0.0-powerpc64le-linux-ubuntu-18.04.tar.xz": "ae34b037cde14f19c3c431de5fc04e06fa43d2cce3f8d44a63659b48afdf1f7a",
+    "clang+llvm-16.0.0-sparc64-unknown-linux-gnu.tar.xz": "a2627fcb6d97405b38c9e4c17ccfdc5d61fdd1bee742dcce0726ed39e2dcd92c",
+    "clang+llvm-16.0.0-sparcv9-sun-solaris2.11.tar.xz": "45c2ac0c10c3876332407a1ea893dccbde77a490f4a9b54a00e4881681a3c5ea",
+    "clang+llvm-16.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz": "2b8a69798e8dddeb57a186ecac217a35ea45607cb2b3cf30014431cff4340ad1",
+
+    # 16.0.1
+    "clang+llvm-16.0.1-aarch64-linux-gnu.tar.xz": "83e38451772120b016432687c0a3aab391808442b86f54966ef44c73a26280ac",
+    "clang+llvm-16.0.1-amd64-unknown-freebsd13.tar.xz": "970359de2a1a09a93a9e1cf3405e5758dfe463567b20a168f9156bd72b7f8ac6",
+    "clang+llvm-16.0.1-arm64-apple-darwin22.0.tar.xz": "cb487fa991f047dc79ae36430cbb9ef14621c1262075373955b1d97215c75879",
+    "clang+llvm-16.0.1-powerpc64-ibm-aix-7.2.tar.xz": "c56d9cf643b7f39e40436e55b59b3bd88057ec0fa084bd8e06ac17fb20ea2a21",
+    "clang+llvm-16.0.1-powerpc64le-linux-rhel-8.4.tar.xz": "c89a9af64a35ee58ef4eac7b52c173707140dc7eac6839ff254b656de8eb6c3c",
+    "clang+llvm-16.0.1-powerpc64le-linux-ubuntu-20.04.tar.xz": "08b39f9e6c19086aaf029d155c42a4db96ce662f84d6e89d8c9037d3baeee036",
+
+    # 16.0.2
+    "clang+llvm-16.0.2-aarch64-linux-gnu.tar.xz": "de89d138cfb17e2d81fdaca2f9c5e0c042014beea6bcacde7f27db40b69c0bdc",
+    "clang+llvm-16.0.2-amd64-unknown-freebsd13.tar.xz": "0cd92b6a84e7477aa8070465f01eec8198e0b1e38d1b6da8c61859a633ec9a71",
+    "clang+llvm-16.0.2-arm64-apple-darwin22.0.tar.xz": "539861297b8aa6be8e89bf68268b07d79d7a1fde87f4b98f123709f13933f326",
+    "clang+llvm-16.0.2-powerpc64-ibm-aix-7.2.tar.xz": "8c9cbf29b261f1af905f41032b446fd78bd560b549ab31d05a16d0cc972df23d",
+    "clang+llvm-16.0.2-powerpc64le-linux-rhel-8.4.tar.xz": "fe21023b64d2298d65fea0f4832a27a9948121662b54a8c8ce8a9331c4039c36",
+    "clang+llvm-16.0.2-x86_64-linux-gnu-ubuntu-22.04.tar.xz": "9530eccdffedb9761f23cbd915cf95d861b1d95f340ea36ded68bd6312af912e",
+
+    # 16.0.3
+    "clang+llvm-16.0.3-aarch64-linux-gnu.tar.xz": "315fd821ddb3e4b10c4dfabe7f200d1d17902b6a5ccd5dd665a0cd454bca379f",
+    "clang+llvm-16.0.3-arm64-apple-darwin22.0.tar.xz": "b9068eee1cf1e17848241ea581a2abe6cb4a15d470ec515c100f8b52e4c6a7cb",
+    "clang+llvm-16.0.3-powerpc64-ibm-aix-7.2.tar.xz": "f0372ea5b665ca1b8524b933b84ccbe59e9441537388815b24323aa4aab7db2f",
+    "clang+llvm-16.0.3-powerpc64le-linux-rhel-8.4.tar.xz": "9804721c746d74a85ce935d938509277af728fad1548835f539660ff1380e04d",
+    "clang+llvm-16.0.3-x86_64-linux-gnu-ubuntu-22.04.tar.xz": "638d32fd0032f99bafaab3bae63a406adb771825a02b6b7da119ee7e71af26c6",
+
+    # 16.0.4
+    "clang+llvm-16.0.4-aarch64-linux-gnu.tar.xz": "2e0b5b20d21ff80dea9f31d3f7636e458028ad0d5ee0bda42608fa8744ea3a12",
+    "clang+llvm-16.0.4-amd64-unknown-freebsd13.tar.xz": "cf9d73bcf05b8749c7f3efbe86654b8fe0209f28993eafe26c27eb85885593f7",
+    "clang+llvm-16.0.4-arm64-apple-darwin22.0.tar.xz": "429b8061d620108fee636313df55a0602ea0d14458c6d3873989e6b130a074bd",
+    "clang+llvm-16.0.4-armv7a-linux-gnueabihf.tar.xz": "e3fafbb5813650cdbfb191005fa8a7b1f036fbadff171e05b32d06015e1feb46",
+    "clang+llvm-16.0.4-powerpc64-ibm-aix-7.2.tar.xz": "af8691731ddd4142c53d9aeb2ad2c4281f4ca9819c5630e7ccade40f39dc4ee5",
+    "clang+llvm-16.0.4-powerpc64le-linux-rhel-8.4.tar.xz": "fe99951300ae7f1877f00531dc5a2f5f00572fa236be6d1323902ea6aeb0a496",
+    "clang+llvm-16.0.4-x86_64-linux-gnu-ubuntu-22.04.tar.xz": "fd464333bd55b482eb7385f2f4e18248eb43129a3cda4c0920ad9ac3c12bdacf",
+
+    # 16.0.5
+    "clang+llvm-16.0.5-aarch64-linux-gnu.tar.xz": "c427d4fa5cd21a11d9fea55ae60ad2e7230ad8411f7a0dea867273f2a1b74891",
+    "clang+llvm-16.0.5-amd64-unknown-freebsd13.tar.xz": "c52d693584d4f86d972acb52be5d14d13ccd815c68ca22114e46829219da3734",
+    "clang+llvm-16.0.5-arm64-apple-darwin22.0.tar.xz": "1aed0787417dd915f0101503ce1d2719c8820a2c92d4a517bfc4044f72035bcc",
+    "clang+llvm-16.0.5-powerpc64-ibm-aix-7.2.tar.xz": "5649575b499deff1470dd1f3baacbee445bf2789de266135d81024572efc54f0",
+    "clang+llvm-16.0.5-powerpc64le-linux-rhel-8.7.tar.xz": "8f2588dabcc2515e860733c2001fb81774aa2d2bccad153f064cfb886df2d065",
+
+    # 16.0.6
+    "clang+llvm-16.0.6-aarch64-linux-gnu.tar.xz": "283e904048425f05798a98f1b288ae0d28ce75eb1049e0837f959e911369945b",
+    "clang+llvm-16.0.6-powerpc64le-linux-rhel-8.7.tar.xz": "1f8d73c342efc82618bd8d58fa8855bc7e70bd2a6ed9646065aabfa4b468e82d",
+
+    # 17.0.1
+    "clang+llvm-17.0.1-aarch64-linux-gnu.tar.xz": "d2eaca72ce3aab0b343e01b2233303628ff43a43a6107dca1aa8d3039da847f5",
+    "clang+llvm-17.0.1-amd64-pc-solaris2.11.tar.xz": "153b8b650705390cc3b4ff739b061f5bff87542531c002c039d52c00781559f7",
+    "clang+llvm-17.0.1-arm64-apple-darwin22.0.tar.xz": "d5678bc475c42c3ab7c0ee35ebd95534d81b6816507cfc9e42d86136d8315ebc",
+    "clang+llvm-17.0.1-final_powerpc64-ibm-aix-7.2.tar.xz": "f5d9bf5822a775d4b10e7af035076e1779983dee1b05b3f57af2674231bcf678",
+    "clang+llvm-17.0.1-powerpc64le-linux-rhel-8.8.tar.xz": "937394cd44c5eb81aae8d1c66b6d3b930ebd2b013ac6493d17f33f5083281d37",
+    "clang+llvm-17.0.1-sparc64-unknown-linux-gnu.tar.xz": "0ab5f6a9b19ec968628d987d9430a033801c78bee65fbf40c72da660ff401f4d",
+    "clang+llvm-17.0.1-sparcv9-sun-solaris2.11.tar.xz": "a69d47bb1397766a87fcdef28260fc664fdf9b6e1f7c56792939baf8513c1694",
+
+    # 17.0.2
+    "clang+llvm-17.0.2-aarch64-linux-gnu.tar.xz": "b08480f2a77167556907869065b0e0e30f4d6cb64ecc625d523b61c22ff0200f",
+    "clang+llvm-17.0.2-amd64-pc-solaris2.11.tar.xz": "8e98c6015202575407f5580bed9a9b58d3bdc3e5d64e39289189b491949b957f",
+    "clang+llvm-17.0.2-arm64-apple-darwin22.0.tar.xz": "dfb3226b3e16f5b8d3882f3ff0e8ebf40b26dd1e97d879197430b930d773ea84",
+    "clang+llvm-17.0.2-powerpc64-ibm-aix-7.2.tar.xz": "c0175b48bf72c621316f3fc7ec4662163d4e17718b179f967d75149d7cfeee80",
+    "clang+llvm-17.0.2-powerpc64le-linux-rhel-8.8.tar.xz": "ef19116996a1966a4fa6e261c86eef7b807e5f39a963dc914b5547976336ab1b",
+    "clang+llvm-17.0.2-sparc64-unknown-linux-gnu.tar.xz": "950d1ef440f17e29c4201450ad619d3b4a37a0bbf15f19ce03195e0b4da7d73f",
+    "clang+llvm-17.0.2-sparcv9-sun-solaris2.11.tar.xz": "3702914668b5758817374271fa8a41fe67c77b2e86f17706c9d6906f250de6ae",
+    "clang+llvm-17.0.2-x86_64-linux-gnu-ubuntu-22.04.tar.xz": "df297df804766f8fb18f10a188af78e55d82bb8881751408c2fa694ca19163a8",
+
+    # 17.0.3
+    "clang+llvm-17.0.3-aarch64-linux-gnu.tar.xz": "289da98e4cbc157153e987ff24ce835717a36cfab03ecd03bf359378ee4ae9d7",
+    "clang+llvm-17.0.3-arm64-apple-darwin22.0.tar.xz": "da452a1aa33954c123d5264bd849ebc572a28e8511b868b43e82d6960fda60d7",
+    "clang+llvm-17.0.3-powerpc64-ibm-aix-7.2.tar.xz": "86b05883c17ddb4b7e9ad6a6a88e78311c117fdc03415fa47293e12e6e2810ff",
+    "clang+llvm-17.0.3-powerpc64le-linux-rhel-8.8.tar.xz": "fcba4ac2a717762ff1b5fe482a811648837d7dc7bf7b654702c80f2fa044d07d",
+
+    # 17.0.4
+    "clang+llvm-17.0.4-aarch64-linux-gnu.tar.xz": "18b326b3e17168fc423726b5059b4d55b6070d49408e51440ad3fca2ebb37779",
+    "clang+llvm-17.0.4-arm64-apple-darwin22.0.tar.xz": "5d514fa64a290dca53288ce859e6ec59a0b48198b3a5b27ca53b6fe80a977b8d",
+    "clang+llvm-17.0.4-powerpc64-ibm-aix-7.2.tar.xz": "54d4d6b91624597e0c0b15264c4c8e57092f521247b87ba6f1297db339ac6e2b",
+    "clang+llvm-17.0.4-powerpc64le-linux-rhel-8.8.tar.xz": "2e3ac8b7288ed5d5c3549e457332bbf3c913022fdd7cfbe13fde46448f76d136",
+    "clang+llvm-17.0.4-x86_64-linux-gnu-ubuntu-22.04.tar.xz": "6b45be6c0483b7ee3f63981678093b731fd9f4ea6987b4ceb6efde21890ffca7",
+
+    # 17.0.5
+    "clang+llvm-17.0.5-aarch64-linux-gnu.tar.xz": "ee12126c404d42a0723ff3a4449470b5570fe5ce610be9d9baee88a6d27701d2",
+    "clang+llvm-17.0.5-arm64-apple-darwin22.0.tar.xz": "6c9aa227800d30d39c28dadbd72c15442e0d9b6813efb2aaa66a478630b7f0c6",
+    "clang+llvm-17.0.5-powerpc64-ibm-aix-7.2.tar.xz": "b5da095901fe604f562363cf9611d6ca73e13d81831a96518823d690babc608f",
+    "clang+llvm-17.0.5-powerpc64le-linux-rhel-8.8.tar.xz": "11aace89d7881b694a05d1e93de3c78a31e141d0df1401491d67f73020bc3df2",
+    "clang+llvm-17.0.5-x86_64-linux-gnu-ubuntu-22.04.tar.xz": "5a3cedecd8e2e8663e84bec2f8e5522b8ea097f4a8b32637386f27ac1ca01818",
+
+    # 17.0.6
+    "clang+llvm-17.0.6-aarch64-linux-gnu.tar.xz": "6dd62762285326f223f40b8e4f2864b5c372de3f7de0731cb7cd55ca5287b75a",
+    "clang+llvm-17.0.6-amd64-pc-solaris2.11.tar.xz": "8feb660750a4d24b18d8e894fbccf26bd0dfbc92581d202ec9057f00f3fbf232",
+    "clang+llvm-17.0.6-arm64-apple-darwin22.0.tar.xz": "1264eb3c2a4a6d5e9354c3e5dc5cb6c6481e678f6456f36d2e0e566e9400fcad",
+    "clang+llvm-17.0.6-powerpc64-ibm-aix-7.2.tar.xz": "3aeda4bb5808db2e47bde60cc49b15b869114e3681092413f7b297345d2e13ce",
+    "clang+llvm-17.0.6-powerpc64le-linux-rhel-8.8.tar.xz": "04e18072797920c2b5e9bdf0c3ee9e5a61adf76bd5ffeb438fafd9e32fc48b62",
+    "clang+llvm-17.0.6-sparcv9-sun-solaris2.11.tar.xz": "b7df7b383679af98640640f88114f461f38a6efdfe7c369692b0675751ac2773",
+    "clang+llvm-17.0.6-x86_64-linux-gnu-ubuntu-22.04.tar.xz": "884ee67d647d77e58740c1e645649e29ae9e8a6fe87c1376be0f3a30f3cc9ab3",
+
+    # 18.1.0
+    "clang+llvm-18.1.0-aarch64-linux-gnu.tar.xz": "32faaad5b6e072d763a603f7c51e4ee63e2d82c16e945524a539df84e3f2b058",
+    "clang+llvm-18.1.0-amd64-pc-solaris2.11.tar.xz": "c352b81dd6add029e3def54a7b90387bb1df15f76497adac0b9f305694eb2d8c",
+    "clang+llvm-18.1.0-powerpc64-ibm-aix-7.2.tar.xz": "cc9bcf2b2132c158a71f7f3971d105454131701c25767f97e977c568418aff89",
+    "clang+llvm-18.1.0-powerpc64le-linux-rhel-8.8.tar.xz": "730c40a0c79d89ca8875c2004fd49180e9b65585b24f68728232b06b3d8bda32",
+    "clang+llvm-18.1.0-sparcv9-sun-solaris2.11.tar.xz": "e871f472ceafbe0197cff81d7240552e45e55ead00fe82f4fb326af32bbfb657",
+    "clang+llvm-18.1.0-sparcv9-unknown-linux-gnu.tar.xz": "0f6d94d9e3eccb5596def41e48b3f8a400f27edc2374e6fc53d0b6baea0d79b3",
+    "clang+llvm-18.1.0-x86_64-pc-windows-msvc.tar.xz": "d128c0f5f7831c77d549296a910fc9972407ff028b720fb628ffa837ed7ff04e",
+
+    # 18.1.1
+    "clang+llvm-18.1.1-aarch64-linux-gnu.tar.xz": "6815ef3c314566605f90cff7922ff3ef5a6eaaf854604e4add6a170e6e98389f",
+    "clang+llvm-18.1.1-powerpc64-ibm-aix-7.2.tar.xz": "c900418e781d0de1f316fcce50ffeca903fa15d97df0dd90f6ac4bd2b43105d4",
+    "clang+llvm-18.1.1-powerpc64le-linux-rhel-8.8.tar.xz": "7415429a0c0eceeacedc00b3f99f9a869909682fab130c2e514f240379539741",
+    "clang+llvm-18.1.1-x86_64-pc-windows-msvc.tar.xz": "79ea242c0fbd66c632ed3aaebf6f821c1e4c03140497c67ea750443eb36bfc5d",
+
+    # 18.1.2
+    "clang+llvm-18.1.2-aarch64-linux-gnu.tar.xz": "aa9d6c6e70cbe2344be1f4b780525a9a4feb70a6e4fa46ea67822f0e7f839c21",
+    "clang+llvm-18.1.2-amd64-pc-solaris2.11.tar.xz": "83ca7644b5eebf5ac55014e628d0bbe685a79416d70a0d80d24ece0ddfc05c6d",
+    "clang+llvm-18.1.2-powerpc64-ibm-aix-7.2.tar.xz": "ad7351206905f61933be5937017fc454995d287346f7f0325c48c4552803af87",
+    "clang+llvm-18.1.2-powerpc64le-linux-rhel-8.8.tar.xz": "0dc4831dab74f47691dab934a52a055ea8fae6bfeec2ed5261991146b38f1cf3",
+    "clang+llvm-18.1.2-sparcv9-sun-solaris2.11.tar.xz": "b719027e8423296f06375ee151652623b0a1df46848dac0bb2614210e5bd233e",
+    "clang+llvm-18.1.2-x86_64-pc-windows-msvc.tar.xz": "0f3df344d9342905ba5ee6b6f669468d9c105a5812b794e7898d7b39780ce3ad",
 }
 
 # Note: Unlike the user-specified llvm_mirror attribute, the URL prefixes in
@@ -169,6 +459,38 @@ _llvm_distributions_base_url = {
     "12.0.0": "https://github.com/llvm/llvm-project/releases/download/llvmorg-",
     "12.0.1": "https://github.com/llvm/llvm-project/releases/download/llvmorg-",
     "13.0.0": "https://github.com/llvm/llvm-project/releases/download/llvmorg-",
+    "13.0.1": "https://github.com/llvm/llvm-project/releases/download/llvmorg-",
+    "14.0.0": "https://github.com/llvm/llvm-project/releases/download/llvmorg-",
+    "14.0.1": "https://github.com/llvm/llvm-project/releases/download/llvmorg-",
+    "14.0.2": "https://github.com/llvm/llvm-project/releases/download/llvmorg-",
+    "14.0.3": "https://github.com/llvm/llvm-project/releases/download/llvmorg-",
+    "14.0.4": "https://github.com/llvm/llvm-project/releases/download/llvmorg-",
+    "14.0.5": "https://github.com/llvm/llvm-project/releases/download/llvmorg-",
+    "14.0.6": "https://github.com/llvm/llvm-project/releases/download/llvmorg-",
+    "15.0.0": "https://github.com/llvm/llvm-project/releases/download/llvmorg-",
+    "15.0.1": "https://github.com/llvm/llvm-project/releases/download/llvmorg-",
+    "15.0.2": "https://github.com/llvm/llvm-project/releases/download/llvmorg-",
+    "15.0.3": "https://github.com/llvm/llvm-project/releases/download/llvmorg-",
+    "15.0.4": "https://github.com/llvm/llvm-project/releases/download/llvmorg-",
+    "15.0.5": "https://github.com/llvm/llvm-project/releases/download/llvmorg-",
+    "15.0.6": "https://github.com/llvm/llvm-project/releases/download/llvmorg-",
+    "15.0.7": "https://github.com/llvm/llvm-project/releases/download/llvmorg-",
+    "16.0.0": "https://github.com/llvm/llvm-project/releases/download/llvmorg-",
+    "16.0.1": "https://github.com/llvm/llvm-project/releases/download/llvmorg-",
+    "16.0.2": "https://github.com/llvm/llvm-project/releases/download/llvmorg-",
+    "16.0.3": "https://github.com/llvm/llvm-project/releases/download/llvmorg-",
+    "16.0.4": "https://github.com/llvm/llvm-project/releases/download/llvmorg-",
+    "16.0.5": "https://github.com/llvm/llvm-project/releases/download/llvmorg-",
+    "16.0.6": "https://github.com/llvm/llvm-project/releases/download/llvmorg-",
+    "17.0.1": "https://github.com/llvm/llvm-project/releases/download/llvmorg-",
+    "17.0.2": "https://github.com/llvm/llvm-project/releases/download/llvmorg-",
+    "17.0.3": "https://github.com/llvm/llvm-project/releases/download/llvmorg-",
+    "17.0.4": "https://github.com/llvm/llvm-project/releases/download/llvmorg-",
+    "17.0.5": "https://github.com/llvm/llvm-project/releases/download/llvmorg-",
+    "17.0.6": "https://github.com/llvm/llvm-project/releases/download/llvmorg-",
+    "18.1.0": "https://github.com/llvm/llvm-project/releases/download/llvmorg-",
+    "18.1.1": "https://github.com/llvm/llvm-project/releases/download/llvmorg-",
+    "18.1.2": "https://github.com/llvm/llvm-project/releases/download/llvmorg-",
 }
 
 def _python(rctx):

--- a/toolchain/internal/llvm_distributions.bzl
+++ b/toolchain/internal/llvm_distributions.bzl
@@ -87,17 +87,14 @@ _llvm_distributions = {
     "clang+llvm-9.0.0-x86_64-darwin-apple.tar.xz": "b46e3fe3829d4eb30ad72993bf28c76b1e1f7e38509fbd44192a2ef7c0126fc7",
 
     # 10.0.0
-    # "clang+llvm-10.0.0-x86_64-pc-linux-gnu.tar.xz": "", As of this writing, Ubuntu 19.10 binaries are not released.
-    # "clang+llvm-10.0.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz": "", As of this writing, Ubuntu 16.04 binaries are not released.
     "clang+llvm-10.0.0-amd64-pc-solaris2.11.tar.xz": "aaf6865542bd772e30be3abf620340a050ed5e4297f8be347e959e5483d9f159",
     "clang+llvm-10.0.0-powerpc64le-linux-ubuntu-16.04.tar.xz": "2d6298720d6aae7fcada4e909f0949d63e94fd0370d20b8882cdd91ceae7511c",
     "clang+llvm-10.0.0-x86_64-linux-sles11.3.tar.xz": "a7a3c2a7aff813bb10932636a6f1612e308256a5e6b5a5655068d5c5b7f80e86",
     "clang+llvm-10.0.0-amd64-unknown-freebsd11.tar.xz": "56d58da545743d5f2947234d413632fd2b840e38f2bed7369f6e65531af36a52",
     "clang+llvm-10.0.0-powerpc64le-linux-rhel-7.4.tar.xz": "958b8a774eae0bb25515d7fb2f13f5ead1450f768ffdcff18b29739613b3c457",
-    # "clang+llvm-10.0.0-x86_64-linux-gnu-ubuntu-14.04.tar.xz": "",  As of this writing, Ubuntu 14.04 binaries are not yet released.
     "clang+llvm-10.0.0-aarch64-linux-gnu.tar.xz": "c2072390dc6c8b4cc67737f487ef384148253a6a97b38030e012c4d7214b7295",
     "clang+llvm-10.0.0-sparcv9-sun-solaris2.11.tar.xz": "725c9205550cabb6d8e0d8b1029176113615809dcc880b347c1577aecdf2af4c",
-    # "clang+llvm-10.0.0-armv7a-linux-gnueabihf.tar.xz": "", As of this writing, armv7a Linux binaries are not yet released.
+    "clang+llvm-10.0.0-armv7a-linux-gnueabihf.tar.xz": "ad136e0d8ce9ac1a341a54513dfd313a7a64c49afa7a69d51cdc2118f7fdc350",
     "clang+llvm-10.0.0-i386-unknown-freebsd11.tar.xz": "310ed47e957c226b0de17130711505366c225edbed65299ac2c3d59f9a59a41a",
     "clang+llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz": "b25f592a0c00686f03e3b7db68ca6dc87418f681f4ead4df4745a01d9be63843",
     "clang+llvm-10.0.0-x86_64-apple-darwin.tar.xz": "633a833396bf2276094c126b072d52b59aca6249e7ce8eae14c728016edb5e61",
@@ -132,6 +129,28 @@ _llvm_distributions = {
     "clang+llvm-12.0.0-x86_64-linux-sles12.4.tar.xz": "00c25261e303080c2e8d55413a73c60913cdb39cfd47587d6817a86fe52565e9",
     "clang+llvm-12.0.0-i386-unknown-freebsd12.tar.xz": "1e61921735fd11754df193826306f0352c99ca6013e22f40a7fc77f0b20162be",
     "clang+llvm-12.0.0-x86_64-linux-gnu-ubuntu-20.04.tar.xz": "a9ff205eb0b73ca7c86afc6432eed1c2d49133bd0d49e47b15be59bbf0dd292e",
+
+    # 12.0.1
+    "clang+llvm-12.0.1-amd64-unknown-freebsd11.tar.xz": "94dfe48d9e483283edbee968056d487a850b30de25258fa48f049cca3ede5db4",
+    "clang+llvm-12.0.1-amd64-unknown-freebsd12.tar.xz": "38857da36489880b0504ae7142b74abe41cf18711a6bb25ca96792d8190e8b0e",
+    "clang+llvm-12.0.1-i386-unknown-freebsd11.tar.xz": "346e14e5a9189838704f096e65579c8e1915f95dcc291aa7f20626ccf9767e04",
+    "clang+llvm-12.0.1-i386-unknown-freebsd12.tar.xz": "1f3b5e99e82165bf3442120ee3cb2c95ca96129cf45c85a52ec8973f8904529d",
+    "clang+llvm-12.0.1-armv7a-linux-gnueabihf.tar.xz": "1ec685b5026f9cc5e7316a5ff2dffd8ff54ad9941e642df19062cc1359842c86",
+    "clang+llvm-12.0.1-aarch64-linux-gnu.tar.xz": "3d4ad804b7c85007686548cbc917ab067bf17eaedeab43d9eb83d3a683d8e9d4",
+    "clang+llvm-12.0.1-powerpc64le-linux-rhel-7.9.tar.xz": "9849fa17fb7eb666744f1e2ce8dcb5d28753c4c482cc6f5e3d2b5ad2108dc2de",
+    "clang+llvm-12.0.1-powerpc64le-linux-ubuntu-18.04.tar.xz": "271b9605b74d904d3cc05dd6a61e927fd5a46d5f6b7541cdc67186eb02b22e4c",
+    "clang+llvm-12.0.1-x86_64-linux-gnu-ubuntu-16.04.tar.xz": "6b3cc55d3ef413be79785c4dc02828ab3bd6b887872b143e3091692fc6acefe7",
+
+    # 13.0.0
+    "clang+llvm-13.0.0-amd64-unknown-freebsd12.tar.xz": "e579747a36ff78aa0a5533fe43bc1ed1f8ed449c9bfec43c358d953ffbbdcf76",
+    "clang+llvm-13.0.0-amd64-unknown-freebsd13.tar.xz": "c4f15e156afaa530eb47ba13c46800275102af535ed48e395aed4c1decc1eaa1",
+    "clang+llvm-13.0.0-i386-unknown-freebsd12.tar.xz": "4d14b19c082438a5ceed61e538e5a0298018b1773e8ba2e990f3fbe33492f48f",
+    "clang+llvm-13.0.0-i386-unknown-freebsd13.tar.xz": "f8e105c6ac2fd517ae5ed8ef9b9bab4b015fe89a06c90c3dd5d5c7933dca2276",
+    "clang+llvm-13.0.0-powerpc64le-linux-rhel-7.9.tar.xz": "cfade83f6da572a8ab0e4796d1f657967b342e98202c26e76c857879fb2fa2d2",
+    "clang+llvm-13.0.0-powerpc64le-linux-ubuntu-18.04.tar.xz": "5d79e9e2919866a91431589355f6d07f35d439458ff12cb8f36093fb314a7028",
+    "clang+llvm-13.0.0-x86_64-apple-darwin.tar.xz": "d051234eca1db1f5e4bc08c64937c879c7098900f7a0370f3ceb7544816a8b09",
+    "clang+llvm-13.0.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz": "76d0bf002ede7a893f69d9ad2c4e101d15a8f4186fbfe24e74856c8449acd7c1",
+    "clang+llvm-13.0.0-x86_64-linux-gnu-ubuntu-20.04.tar.xz": "2c2fb857af97f41a5032e9ecadf7f78d3eff389a5cd3c9ec620d24f134ceb3c8",
 }
 
 # Note: Unlike the user-specified llvm_mirror attribute, the URL prefixes in
@@ -148,6 +167,8 @@ _llvm_distributions_base_url = {
     "10.0.1": "https://github.com/llvm/llvm-project/releases/download/llvmorg-",
     "11.0.0": "https://github.com/llvm/llvm-project/releases/download/llvmorg-",
     "12.0.0": "https://github.com/llvm/llvm-project/releases/download/llvmorg-",
+    "12.0.1": "https://github.com/llvm/llvm-project/releases/download/llvmorg-",
+    "13.0.0": "https://github.com/llvm/llvm-project/releases/download/llvmorg-",
 }
 
 def _python(rctx):

--- a/toolchain/internal/llvm_distributions.bzl
+++ b/toolchain/internal/llvm_distributions.bzl
@@ -156,8 +156,8 @@ def download_llvm_preconfigured(rctx):
     llvm_version = rctx.attr.llvm_version
 
     mirror_base = []
-    if rctx.attr.llvm_mirror:
-        mirror_base += [rctx.attr.llvm_mirror]
+    if rctx.attr.llvm_mirror_prefixes:
+        mirror_base += rctx.attr.llvm_mirror_prefixes
 
     if rctx.attr.distribution == "auto":
         exec_result = rctx.execute([
@@ -181,7 +181,7 @@ def download_llvm_preconfigured(rctx):
         "{0}{1}".format(_llvm_distributions_base_url[llvm_version], url_suffix),
     ]
     urls += [
-        "{0}/{1}".format(base, url_suffix)
+        "{0}{1}".format(base, url_suffix)
         for base in mirror_base
     ]
 

--- a/toolchain/rules.bzl
+++ b/toolchain/rules.bzl
@@ -48,7 +48,7 @@ llvm_toolchain = repository_rule(
                    "directories, keyed by the CPU type (e.g. k8 or darwin). See documentation " +
                    "for bazel's create_cc_toolchain_config_info."),
         ),
-        "llvm_mirror": attr.string(
+        "llvm_mirror_prefixes": attr.string_list(
             doc = "Mirror base for LLVM binaries if using the pre-configured URLs.",
         ),
         "absolute_paths": attr.bool(

--- a/toolchain/toolchains.bzl.tpl
+++ b/toolchain/toolchains.bzl.tpl
@@ -14,6 +14,7 @@
 
 def llvm_register_toolchains():
     native.register_toolchains(
-        "@%{repo_name}//:cc-toolchain-linux",
+        "@%{repo_name}//:cc-toolchain-linux-aarch64",
+        "@%{repo_name}//:cc-toolchain-linux-x86_64",
         "@%{repo_name}//:cc-toolchain-darwin",
     )

--- a/toolchain/toolchains.bzl.tpl
+++ b/toolchain/toolchains.bzl.tpl
@@ -16,5 +16,6 @@ def llvm_register_toolchains():
     native.register_toolchains(
         "@%{repo_name}//:cc-toolchain-linux-aarch64",
         "@%{repo_name}//:cc-toolchain-linux-x86_64",
-        "@%{repo_name}//:cc-toolchain-darwin",
+        "@%{repo_name}//:cc-toolchain-darwin-arm64",
+        "@%{repo_name}//:cc-toolchain-darwin-x86_64",
     )

--- a/toolchain/tools/llvm_release_name.py
+++ b/toolchain/tools/llvm_release_name.py
@@ -110,7 +110,7 @@ def _linux(llvm_version):
         os_name = "linux-sles%s" % version
     elif distname == "ubuntu" and version.startswith("14.04"):
         os_name = "linux-gnu-ubuntu-14.04"
-    elif (distname == "ubuntu" or distname == "linuxmint" or distname == "pop") and version.startswith("20"):
+    elif (distname == "ubuntu" or distname == "linuxmint" or distname == "pop") and (version.startswith("20") or version.startswith("22")):
         if major_llvm_version < 11:
             # There is no binary packages specifically for 20.04, but those for 18.04 works on
             # 20.04

--- a/toolchain/tools/llvm_release_name.py
+++ b/toolchain/tools/llvm_release_name.py
@@ -77,7 +77,7 @@ def _linux(llvm_version):
         os_name = "linux-sles%s" % version
     elif distname == "ubuntu" and version.startswith("14.04"):
         os_name = "linux-gnu-ubuntu-14.04"
-    elif (distname == "ubuntu" and version.startswith("20")) or (distname == "linuxmint" and version.startswith("20")):
+    elif (distname == "ubuntu" or distname == "linuxmint" or distname == "pop") and version.startswith("20"):
         if major_llvm_version < 11:
             # There is no binary packages specifically for 20.04, but those for 18.04 works on
             # 20.04
@@ -85,13 +85,13 @@ def _linux(llvm_version):
         else:
             # release 11.0.0 started providing packaging for ubuntu 20
             os_name = "linux-gnu-ubuntu-20.04"
-
+            
     elif (distname == "ubuntu" and version.startswith("18.04")) or (distname == "linuxmint" and version.startswith("19")):
         if major_llvm_version >= 12:
+            # There is no binary release of 12.0.0 for 18.04, but 16.04 works
             os_name = "linux-gnu-ubuntu-16.04"
         else:
             os_name = "linux-gnu-ubuntu-18.04"
-
     elif distname in ["arch", "ubuntu", "manjaro"] or (distname == "linuxmint" and version.startswith("18")):
         os_name = "linux-gnu-ubuntu-16.04"
     elif distname == "debian" and (version is None or int(version) == 10):

--- a/toolchain/tools/llvm_release_name.py
+++ b/toolchain/tools/llvm_release_name.py
@@ -17,7 +17,7 @@
 import platform
 import sys
 
-_known_distros = ["freebsd", "suse", "ubuntu", "arch", "manjaro", "debian", "fedora", "centos"]
+_known_distros = ["freebsd", "suse", "ubuntu", "arch", "manjaro", "debian", "fedora", "centos", "void"]
 
 def _major_llvm_version(llvm_version):
     return int(llvm_version.split(".")[0])
@@ -109,6 +109,8 @@ def _linux(llvm_version):
         os_name = "linux-gnu-ubuntu-18.04"
     elif distname == "amzn" and major_llvm_version >= 7:
         os_name = "linux-gnu-ubuntu-18.04"
+    elif distname == "void" and major_llvm_version >= 7:
+        os_name = "linux-gnu-ubuntu-20.04"
     else:
         sys.exit("Unsupported linux distribution and version: %s, %s" % (distname, version))
 

--- a/toolchain/tools/llvm_release_name.py
+++ b/toolchain/tools/llvm_release_name.py
@@ -77,7 +77,7 @@ def _linux(llvm_version):
         os_name = "linux-sles%s" % version
     elif distname == "ubuntu" and version.startswith("14.04"):
         os_name = "linux-gnu-ubuntu-14.04"
-    elif (distname == "ubuntu" and version.startswith("20.04")) or (distname == "linuxmint" and version.startswith("20")):
+    elif (distname == "ubuntu" and version.startswith("20")) or (distname == "linuxmint" and version.startswith("20")):
         if major_llvm_version < 11:
             # There is no binary packages specifically for 20.04, but those for 18.04 works on
             # 20.04
@@ -90,13 +90,6 @@ def _linux(llvm_version):
         if major_llvm_version >= 12:
             os_name = "linux-gnu-ubuntu-16.04"
         else:
-            os_name = "linux-gnu-ubuntu-18.04"
-
-    elif (distname == "ubuntu" and version.startswith("20")) or (distname == "pop" and version.startswith("20")):
-        if major_llvm_version >= 12:
-            os_name = "linux-gnu-ubuntu-20.04"
-        else:
-            # use ubuntu 18.04 clang LLVM release for ubuntu 20.04
             os_name = "linux-gnu-ubuntu-18.04"
 
     elif distname in ["arch", "ubuntu", "manjaro"] or (distname == "linuxmint" and version.startswith("18")):

--- a/toolchain/tools/llvm_release_name.py
+++ b/toolchain/tools/llvm_release_name.py
@@ -51,9 +51,9 @@ def _darwin_apple_suffix(llvm_version, arch):
     else:
         return "apple-darwin"
 
-def _darwin(llvm_version, arch):
-    if arch == "aarch64":
-        arch = "arm64"
+def _darwin(llvm_version):
+    arch = platform.machine()
+
     suffix = _darwin_apple_suffix(llvm_version, arch)
     return "clang+llvm-{llvm_version}-{arch}-{suffix}.tar.xz".format(
         llvm_version = llvm_version,
@@ -162,7 +162,7 @@ def main():
 
     system = platform.system()
     if system == "Darwin":
-        print(_darwin(llvm_version, "x86_64"))
+        print(_darwin(llvm_version))
         sys.exit()
 
     if system == "Windows":

--- a/toolchain/tools/llvm_release_name.py
+++ b/toolchain/tools/llvm_release_name.py
@@ -85,15 +85,20 @@ def _linux(llvm_version):
         else:
             # release 11.0.0 started providing packaging for ubuntu 20
             os_name = "linux-gnu-ubuntu-20.04"
-            
+
     elif (distname == "ubuntu" and version.startswith("18.04")) or (distname == "linuxmint" and version.startswith("19")):
         if major_llvm_version >= 12:
             os_name = "linux-gnu-ubuntu-16.04"
         else:
             os_name = "linux-gnu-ubuntu-18.04"
+
     elif (distname == "ubuntu" and version.startswith("20")) or (distname == "pop" and version.startswith("20")):
-        # use ubuntu 18.04 clang LLVM release for ubuntu 20.04
-        os_name = "linux-gnu-ubuntu-18.04"
+        if major_llvm_version >= 12:
+            os_name = "linux-gnu-ubuntu-20.04"
+        else:
+            # use ubuntu 18.04 clang LLVM release for ubuntu 20.04
+            os_name = "linux-gnu-ubuntu-18.04"
+
     elif distname in ["arch", "ubuntu", "manjaro"] or (distname == "linuxmint" and version.startswith("18")):
         os_name = "linux-gnu-ubuntu-16.04"
     elif distname == "debian" and (version is None or int(version) == 10):

--- a/toolchain/tools/llvm_release_name.py
+++ b/toolchain/tools/llvm_release_name.py
@@ -87,7 +87,10 @@ def _linux(llvm_version):
             os_name = "linux-gnu-ubuntu-20.04"
             
     elif (distname == "ubuntu" and version.startswith("18.04")) or (distname == "linuxmint" and version.startswith("19")):
-        os_name = "linux-gnu-ubuntu-18.04"
+        if major_llvm_version >= 12:
+            os_name = "linux-gnu-ubuntu-16.04"
+        else:
+            os_name = "linux-gnu-ubuntu-18.04"
     elif (distname == "ubuntu" and version.startswith("20")) or (distname == "pop" and version.startswith("20")):
         # use ubuntu 18.04 clang LLVM release for ubuntu 20.04
         os_name = "linux-gnu-ubuntu-18.04"


### PR DESCRIPTION
Two main changes:

* Update the `toolchain/tools/llvm_release_name.py` script to properly resolve the LLVM release name for Darwin22 ARM64
* Update the `llvm_toolchain` toolchain definition to support Darwin ARM64 compilation

These changes can be tested with https://github.com/sorbet/sorbet/compare/master...Morriar:sorbet:at-arm64?expand=1:

```
$ ./bazel build //main:sorbet --config=release-mac-arm64
$ file bazel-bin/main/sorbet
bazel-bin/main/sorbet: Mach-O 64-bit executable arm64
```