### PR TITLE
Fix cross compilation from darwin x86_64 to darwin arm64

### DIFF
--- a/toolchain/cc_toolchain_config.bzl
+++ b/toolchain/cc_toolchain_config.bzl
@@ -149,7 +149,7 @@ def cc_toolchain_config(
     link_libs = []
 
     # Linker flags:
-    if host_os == "darwin" and not is_xcompile:
+    if host_os == "darwin" and target_os == "darwin":
         use_lld = False
         ld_name = "ld64.lld"
         link_flags.extend([
@@ -175,7 +175,7 @@ def cc_toolchain_config(
     # always link C++ libraries.
     cxx_standard = compiler_configuration["cxx_standard"]
     stdlib = compiler_configuration["stdlib"]
-    if stdlib == "builtin-libc++" and is_xcompile:
+    if stdlib == "builtin-libc++" and is_xcompile and not target_os == "darwin":
         stdlib = "stdc++"
     if stdlib == "builtin-libc++":
         cxx_flags = [


### PR DESCRIPTION
The compiling options selection logic is currently tailored for a cross compilation from darwin to linux platform and doesn't work when compiling from darwin x86_64 to darwin arm64.

We found and fixed two main issues:

1. When on a darwin host with the `is_xcompile` flag set to true, the toolchain will incorrectly select the `stdc++` which is deprecated since XCode 10 (see https://forums.developer.apple.com/forums/thread/113746) instead it should default to `libc++`.

2. Again, when on a darwin host with the `is_xcompile` the toolchain will default to passing `lld` compatible flags which are not recognized by `ld64`.

See https://github.com/Shopify/sorbet/tree/vs-support-arm64-compilation for a working version able to compile Sorbet from darwin x86_64 to darwin arm64.

