### PR TITLE
Also symlink `include/` folder alongside the tools

### DIFF
--- a/toolchain/internal/configure.bzl
+++ b/toolchain/internal/configure.bzl
@@ -125,6 +125,9 @@ def llvm_config_impl(rctx):
         tools = _toolchain_tools(os)
         for tool_name, symlink_name in tools.items():
             rctx.symlink(llvm_dist_rel_path + "bin/" + tool_name, tools_path_prefix + symlink_name)
+            if tool_name == "clangd":
+                # A symlinked `clangd` looks for `include/` headers relative to itself
+                rctx.symlink(llvm_dist_rel_path + "include", "include")
         symlinked_tools_str = "".join([
             "\n" + (" " * 8) + "\"" + tools_path_prefix + symlink_name + "\","
             for symlink_name in tools.values()
@@ -602,6 +605,9 @@ def _convenience_targets_str(rctx, use_absolute_paths, llvm_dist_rel_path, llvm_
         for toolname in _aliased_tools:
             filename = "bin/{}".format(toolname)
             filenames.append(filename)
+            if toolname == "clangd":
+                # A symlinked `clangd` looks for `include/` headers relative to itself
+                filenames.append("include")
 
         for filename in filenames:
             rctx.symlink(llvm_dist_rel_path + filename, filename)


### PR DESCRIPTION
The `clangd` troubleshooting page[^1] mentions that if you're struggling
to get clangd to find stdlib headers, you might benefit from absolutely
qualifying the path to `clangd`.

That made me think that clangd is looking e.g. in the realpath of
`external/llvm_toolchain_15_0_7` for an `include/` folder to find the
system headers. But in our bazel sandbox, that external folder only had
`bin` and `lib`, not `include`, so clangd failed to find them.

This change includes those symlinks if `clangd` is one of the aliased
tools. We could also choose to do this unconditionally, though I figured
I'd start with this.

[1] <https://clangd.llvm.org/troubleshooting#cant-find-standard-library-headers-map-stdioh-etc>