### PR TITLE
Fix sanitization of param files in cc_wrapper.sh.tpl

### DIFF
--- a/toolchain/cc_wrapper.sh.tpl
+++ b/toolchain/cc_wrapper.sh.tpl
@@ -109,7 +109,7 @@ function sanitize_option() {
 
 cmd=()
 for ((i = 0; i <= $#; i++)); do
-  if [[ ${!i} == @* && -r "${i:1}" ]]; then
+  if [[ ${!i} == @* && -r "${!i:1}" ]]; then
     # Create a new, sanitized file.
     tmpfile=$(mktemp)
     CLEANUP_FILES+=("${tmpfile}")


### PR DESCRIPTION
Fix the test for sanitizing parameter files in `cc_wrapper.sh.tpl`.
