### PR TITLE
Revert static linking changes for macos

### DIFF
--- a/toolchain/cc_toolchain_config.bzl
+++ b/toolchain/cc_toolchain_config.bzl
@@ -194,9 +194,6 @@ def cc_toolchain_config(
         "-fdata-sections",
     ]
 
-    # By default, we use the `lld` linker that comes with the llvm dist.
-    ld_name = "lld"
-
     link_flags = [
         "--target=" + target_system_name,
         "-no-canonical-prefixes",
@@ -223,11 +220,7 @@ def cc_toolchain_config(
         # TODO: How do we cross-compile from Linux to Darwin?
         use_lld = False
 
-        # Use the ld64.lld linker included with the llvm release.
-        ld_name = "ld64.lld"
-
         link_flags.extend([
-            "-fuse-ld=ld64.lld",
             "-headerpad_max_install_names",
             "-fobjc-link-runtime",
         ])
@@ -303,8 +296,8 @@ def cc_toolchain_config(
             # directory back after we are done.
             link_flags.extend([
                 "-L{}/usr/lib".format(sysroot_path),
-                "{}lib/libc++.a".format(toolchain_path_prefix),
-                "{}lib/libc++abi.a".format(toolchain_path_prefix)
+                "-lc++",
+                "-lc++abi",
             ])
             libunwind_link_flags = []
 
@@ -382,7 +375,7 @@ def cc_toolchain_config(
         "dwp": tools_path_prefix + "llvm-dwp",
         "gcc": wrapper_bin_prefix + "cc_wrapper.sh",
         "gcov": tools_path_prefix + "llvm-profdata",
-        "ld": tools_path_prefix + ld_name,
+        "ld": tools_path_prefix + "ld.lld" if use_lld else "/usr/bin/ld",
         "llvm-cov": tools_path_prefix + "llvm-cov",
         "llvm-profdata": tools_path_prefix + "llvm-profdata",
         "nm": tools_path_prefix + "llvm-nm",

--- a/toolchain/osx_cc_wrapper.sh.tpl
+++ b/toolchain/osx_cc_wrapper.sh.tpl
@@ -140,15 +140,22 @@ for ((i = 0; i <= $#; i++)); do
     tmpfile=$(mktemp)
     CLEANUP_FILES+=("${tmpfile}")
     while IFS= read -r opt; do
+      # We need to set both -fuse-ld=lld and --ld-path to use ld64.lld
+      if [[ ${opt} == "-fuse-ld=ld64.lld" ]]; then
+        echo "-fuse-ld=lld" >>${tmpfile}
+      fi
       opt="$(
         set -e
         sanitize_option "${opt}"
       )"
       parse_option "${opt}"
-      echo "${opt}" >> ${tmpfile}
+      echo "${opt}" >>${tmpfile}
     done <"${!i:1}"
     cmd+=("@${tmpfile}")
   else
+    if [[ ${!i} == "-fuse-ld=ld64.lld" ]]; then
+      cmd+=("-fuse-ld=lld")
+    fi
     opt="$(
       set -e
       sanitize_option "${!i}"


### PR DESCRIPTION
This partially reverts the changes introduced in #12, as the version of ld64.lld that's bundled in llvm-15.0.7 does not work on macos 26.

This PR also makes one final change to support `-fuse-ld-ld64.lld`, by adding `-fuse-ld=lld` in addition to `--ld-path=...` when sanitizing that flag, as it's recommended to pass both when using `ld64.lld`.
